### PR TITLE
[FEAT][#2] 사용자 인증(로그인, 회원가입) View 구현

### DIFF
--- a/momoIOS.xcodeproj/project.pbxproj
+++ b/momoIOS.xcodeproj/project.pbxproj
@@ -1,524 +1,530 @@
 // !$*UTF8*$!
 {
-	archiveVersion = 1;
-	classes = {
-	};
-	objectVersion = 56;
-	objects = {
+    archiveVersion = 1;
+    classes = {
+    };
+    objectVersion = 56;
+    objects = {
 
 /* Begin PBXBuildFile section */
-		3A5AC31029898B330080323A /* UIButton+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5AC30F29898B330080323A /* UIButton+Extension.swift */; };
-		3A75FC10298827BE00B36A46 /* MainAttendanceCodeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A75FC0F298827BE00B36A46 /* MainAttendanceCodeCell.swift */; };
-		3AA713C929884007006F922F /* MainAttendanceDoneCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA713C829884007006F922F /* MainAttendanceDoneCell.swift */; };
-		3AA713D1298946FF006F922F /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA713D0298946FF006F922F /* UIColor+Extension.swift */; };
-		E820792B298A119900B36FC9 /* MainSessionDetailCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E820792A298A119900B36FC9 /* MainSessionDetailCell.swift */; };
-		E820792D298A137700B36FC9 /* MainSessionTimeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E820792C298A137700B36FC9 /* MainSessionTimeCell.swift */; };
-		E820792F298A138500B36FC9 /* MainSessionAbsentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E820792E298A138500B36FC9 /* MainSessionAbsentCell.swift */; };
-		E8207932298A163400B36FC9 /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8207931298A163400B36FC9 /* UIView+Extension.swift */; };
-		E8207934298A22D000B36FC9 /* MainSessionInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8207933298A22D000B36FC9 /* MainSessionInfoCell.swift */; };
-		E8207936298A248200B36FC9 /* MainSessionNoInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8207935298A248100B36FC9 /* MainSessionNoInfoCell.swift */; };
-		BF0408632987B3AA00F1129B /* LoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0408622987B3AA00F1129B /* LoginController.swift */; };
-		BF04086B2987E34800F1129B /* AuthCommonConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086A2987E34800F1129B /* AuthCommonConstants.swift */; };
-		BF04086D2987E38C00F1129B /* RegistrationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086C2987E38C00F1129B /* RegistrationController.swift */; };
-		BF04086F2987E70200F1129B /* CheckSecurityCodeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086E2987E70200F1129B /* CheckSecurityCodeController.swift */; };
-		E83238E92984FDDA00DC83C2 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E83238E82984FDDA00DC83C2 /* RxSwift */; };
-		E83238EC2984FE0800DC83C2 /* Toast in Frameworks */ = {isa = PBXBuildFile; productRef = E83238EB2984FE0800DC83C2 /* Toast */; };
-		E83238EF2984FE3200DC83C2 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = E83238EE2984FE3200DC83C2 /* Alamofire */; };
-		E83238F1298506A000DC83C2 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E83238F0298506A000DC83C2 /* MainViewController.swift */; };
-		E8D5C3F12984FC23003D1AD0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D5C3F02984FC23003D1AD0 /* AppDelegate.swift */; };
-		E8D5C3F32984FC23003D1AD0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D5C3F22984FC23003D1AD0 /* SceneDelegate.swift */; };
-		E8D5C3F52984FC23003D1AD0 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D5C3F42984FC23003D1AD0 /* ViewController.swift */; };
-		E8D5C3FA2984FC25003D1AD0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E8D5C3F92984FC25003D1AD0 /* Assets.xcassets */; };
-		E8D5C4072984FD73003D1AD0 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = E8D5C4062984FD73003D1AD0 /* SnapKit */; };
+        3A5AC31029898B330080323A /* UIButton+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5AC30F29898B330080323A /* UIButton+Extension.swift */; };
+        3A75FC10298827BE00B36A46 /* MainAttendanceCodeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A75FC0F298827BE00B36A46 /* MainAttendanceCodeCell.swift */; };
+        3AA713C929884007006F922F /* MainAttendanceDoneCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA713C829884007006F922F /* MainAttendanceDoneCell.swift */; };
+        3AA713D1298946FF006F922F /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA713D0298946FF006F922F /* UIColor+Extension.swift */; };
+        BF0408632987B3AA00F1129B /* LoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0408622987B3AA00F1129B /* LoginController.swift */; };
+        BF04086B2987E34800F1129B /* AuthCommonConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086A2987E34800F1129B /* AuthCommonConstants.swift */; };
+        BF04086D2987E38C00F1129B /* RegistrationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086C2987E38C00F1129B /* RegistrationController.swift */; };
+        BF04086F2987E70200F1129B /* CheckSecurityCodeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086E2987E70200F1129B /* CheckSecurityCodeController.swift */; };
+        BF998900298BB0D3005723C7 /* InputMemberInfoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9988FF298BB0D3005723C7 /* InputMemberInfoController.swift */; };
+        E820792B298A119900B36FC9 /* MainSessionDetailCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E820792A298A119900B36FC9 /* MainSessionDetailCell.swift */; };
+        E820792D298A137700B36FC9 /* MainSessionTimeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E820792C298A137700B36FC9 /* MainSessionTimeCell.swift */; };
+        E820792F298A138500B36FC9 /* MainSessionAbsentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E820792E298A138500B36FC9 /* MainSessionAbsentCell.swift */; };
+        E8207932298A163400B36FC9 /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8207931298A163400B36FC9 /* UIView+Extension.swift */; };
+        E8207934298A22D000B36FC9 /* MainSessionInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8207933298A22D000B36FC9 /* MainSessionInfoCell.swift */; };
+        E8207936298A248200B36FC9 /* MainSessionNoInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8207935298A248100B36FC9 /* MainSessionNoInfoCell.swift */; };
+        E83238E92984FDDA00DC83C2 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E83238E82984FDDA00DC83C2 /* RxSwift */; };
+        E83238EC2984FE0800DC83C2 /* Toast in Frameworks */ = {isa = PBXBuildFile; productRef = E83238EB2984FE0800DC83C2 /* Toast */; };
+        E83238EF2984FE3200DC83C2 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = E83238EE2984FE3200DC83C2 /* Alamofire */; };
+        E83238F1298506A000DC83C2 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E83238F0298506A000DC83C2 /* MainViewController.swift */; };
+        E8D5C3F12984FC23003D1AD0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D5C3F02984FC23003D1AD0 /* AppDelegate.swift */; };
+        E8D5C3F32984FC23003D1AD0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D5C3F22984FC23003D1AD0 /* SceneDelegate.swift */; };
+        E8D5C3F52984FC23003D1AD0 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D5C3F42984FC23003D1AD0 /* ViewController.swift */; };
+        E8D5C3FA2984FC25003D1AD0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E8D5C3F92984FC25003D1AD0 /* Assets.xcassets */; };
+        E8D5C4072984FD73003D1AD0 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = E8D5C4062984FD73003D1AD0 /* SnapKit */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		3A5AC30F29898B330080323A /* UIButton+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Extension.swift"; sourceTree = "<group>"; };
-		3A75FC0F298827BE00B36A46 /* MainAttendanceCodeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainAttendanceCodeCell.swift; sourceTree = "<group>"; };
-		3AA713C829884007006F922F /* MainAttendanceDoneCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainAttendanceDoneCell.swift; sourceTree = "<group>"; };
-		3AA713D0298946FF006F922F /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
-		E820792A298A119900B36FC9 /* MainSessionDetailCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSessionDetailCell.swift; sourceTree = "<group>"; };
-		E820792C298A137700B36FC9 /* MainSessionTimeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSessionTimeCell.swift; sourceTree = "<group>"; };
-		E820792E298A138500B36FC9 /* MainSessionAbsentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSessionAbsentCell.swift; sourceTree = "<group>"; };
-		E8207931298A163400B36FC9 /* UIView+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
-		E8207933298A22D000B36FC9 /* MainSessionInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSessionInfoCell.swift; sourceTree = "<group>"; };
-		E8207935298A248100B36FC9 /* MainSessionNoInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSessionNoInfoCell.swift; sourceTree = "<group>"; };
-		BF0408622987B3AA00F1129B /* LoginController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginController.swift; sourceTree = "<group>"; };
-		BF04086A2987E34800F1129B /* AuthCommonConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCommonConstants.swift; sourceTree = "<group>"; };
-		BF04086C2987E38C00F1129B /* RegistrationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationController.swift; sourceTree = "<group>"; };
-		BF04086E2987E70200F1129B /* CheckSecurityCodeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckSecurityCodeController.swift; sourceTree = "<group>"; };
-		E83238F0298506A000DC83C2 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
-		E8D5C3ED2984FC23003D1AD0 /* momoIOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = momoIOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		E8D5C3F02984FC23003D1AD0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		E8D5C3F22984FC23003D1AD0 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		E8D5C3F42984FC23003D1AD0 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
-		E8D5C3F92984FC25003D1AD0 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		E8D5C3FE2984FC25003D1AD0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+        3A5AC30F29898B330080323A /* UIButton+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Extension.swift"; sourceTree = "<group>"; };
+        3A75FC0F298827BE00B36A46 /* MainAttendanceCodeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainAttendanceCodeCell.swift; sourceTree = "<group>"; };
+        3AA713C829884007006F922F /* MainAttendanceDoneCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainAttendanceDoneCell.swift; sourceTree = "<group>"; };
+        3AA713D0298946FF006F922F /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
+        BF0408622987B3AA00F1129B /* LoginController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginController.swift; sourceTree = "<group>"; };
+        BF04086A2987E34800F1129B /* AuthCommonConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCommonConstants.swift; sourceTree = "<group>"; };
+        BF04086C2987E38C00F1129B /* RegistrationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationController.swift; sourceTree = "<group>"; };
+        BF04086E2987E70200F1129B /* CheckSecurityCodeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckSecurityCodeController.swift; sourceTree = "<group>"; };
+        BF9988FF298BB0D3005723C7 /* InputMemberInfoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputMemberInfoController.swift; sourceTree = "<group>"; };
+        E820792A298A119900B36FC9 /* MainSessionDetailCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSessionDetailCell.swift; sourceTree = "<group>"; };
+        E820792C298A137700B36FC9 /* MainSessionTimeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSessionTimeCell.swift; sourceTree = "<group>"; };
+        E820792E298A138500B36FC9 /* MainSessionAbsentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSessionAbsentCell.swift; sourceTree = "<group>"; };
+        E8207931298A163400B36FC9 /* UIView+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
+        E8207933298A22D000B36FC9 /* MainSessionInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSessionInfoCell.swift; sourceTree = "<group>"; };
+        E8207935298A248100B36FC9 /* MainSessionNoInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSessionNoInfoCell.swift; sourceTree = "<group>"; };
+        E83238F0298506A000DC83C2 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
+        E8D5C3ED2984FC23003D1AD0 /* momoIOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = momoIOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+        E8D5C3F02984FC23003D1AD0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+        E8D5C3F22984FC23003D1AD0 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+        E8D5C3F42984FC23003D1AD0 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+        E8D5C3F92984FC25003D1AD0 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+        E8D5C3FE2984FC25003D1AD0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		E8D5C3EA2984FC23003D1AD0 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				E83238EC2984FE0800DC83C2 /* Toast in Frameworks */,
-				E83238EF2984FE3200DC83C2 /* Alamofire in Frameworks */,
-				E83238E92984FDDA00DC83C2 /* RxSwift in Frameworks */,
-				E8D5C4072984FD73003D1AD0 /* SnapKit in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+        E8D5C3EA2984FC23003D1AD0 /* Frameworks */ = {
+            isa = PBXFrameworksBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+                E83238EC2984FE0800DC83C2 /* Toast in Frameworks */,
+                E83238EF2984FE3200DC83C2 /* Alamofire in Frameworks */,
+                E83238E92984FDDA00DC83C2 /* RxSwift in Frameworks */,
+                E8D5C4072984FD73003D1AD0 /* SnapKit in Frameworks */,
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		E8207929298A116700B36FC9 /* MainSession */ = {
-			isa = PBXGroup;
-			children = (
-				E820792A298A119900B36FC9 /* MainSessionDetailCell.swift */,
-				E820792C298A137700B36FC9 /* MainSessionTimeCell.swift */,
-				E820792E298A138500B36FC9 /* MainSessionAbsentCell.swift */,
-				E8207933298A22D000B36FC9 /* MainSessionInfoCell.swift */,
-				E8207935298A248100B36FC9 /* MainSessionNoInfoCell.swift */,
-			);
-			path = MainSession;
-			sourceTree = "<group>";
-		};
-		E8207930298A163400B36FC9 /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-				E8207931298A163400B36FC9 /* UIView+Extension.swift */,
-			);
-			path = Extensions;
-		BF0408602987B3AA00F1129B /* Authentication */ = {
-			isa = PBXGroup;
-			children = (
-				BF0408612987B3AA00F1129B /* Controller */,
-			);
-			path = Authentication;
-			sourceTree = "<group>";
-		};
-		BF0408612987B3AA00F1129B /* Controller */ = {
-			isa = PBXGroup;
-			children = (
-				BF0408622987B3AA00F1129B /* LoginController.swift */,
-				BF04086C2987E38C00F1129B /* RegistrationController.swift */,
-				BF04086A2987E34800F1129B /* AuthCommonConstants.swift */,
-				BF04086E2987E70200F1129B /* CheckSecurityCodeController.swift */,
-			);
-			path = Controller;
-			sourceTree = "<group>";
-		};
-		E8D5C3E42984FC23003D1AD0 = {
-			isa = PBXGroup;
-			children = (
-				E8207930298A163400B36FC9 /* Extensions */,
-				E8207929298A116700B36FC9 /* MainSession */,
-				E8D5C3EF2984FC23003D1AD0 /* momoIOS */,
-				E8D5C3EE2984FC23003D1AD0 /* Products */,
-			);
-			sourceTree = "<group>";
-		};
-		E8D5C3EE2984FC23003D1AD0 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				E8D5C3ED2984FC23003D1AD0 /* momoIOS.app */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		E8D5C3EF2984FC23003D1AD0 /* momoIOS */ = {
-			isa = PBXGroup;
-			children = (
-				BF0408602987B3AA00F1129B /* Authentication */,
-				E8D5C3F02984FC23003D1AD0 /* AppDelegate.swift */,
-				E8D5C3F22984FC23003D1AD0 /* SceneDelegate.swift */,
-				E8D5C3F42984FC23003D1AD0 /* ViewController.swift */,
-				E83238F0298506A000DC83C2 /* MainViewController.swift */,
-				3A75FC0F298827BE00B36A46 /* MainAttendanceCodeCell.swift */,
-				3AA713C829884007006F922F /* MainAttendanceDoneCell.swift */,
-				3A5AC30F29898B330080323A /* UIButton+Extension.swift */,
-				3AA713D0298946FF006F922F /* UIColor+Extension.swift */,
-				E8D5C3F92984FC25003D1AD0 /* Assets.xcassets */,
-				E8D5C3FE2984FC25003D1AD0 /* Info.plist */,
-			);
-			path = momoIOS;
-			sourceTree = "<group>";
-		};
+        BF0408602987B3AA00F1129B /* Authentication */ = {
+            isa = PBXGroup;
+            children = (
+                BF0408612987B3AA00F1129B /* Controller */,
+            );
+            path = Authentication;
+            sourceTree = "<group>";
+        };
+        BF0408612987B3AA00F1129B /* Controller */ = {
+            isa = PBXGroup;
+            children = (
+                BF0408622987B3AA00F1129B /* LoginController.swift */,
+                BF04086C2987E38C00F1129B /* RegistrationController.swift */,
+                BF9988FF298BB0D3005723C7 /* InputMemberInfoController.swift */,
+                BF04086A2987E34800F1129B /* AuthCommonConstants.swift */,
+                BF04086E2987E70200F1129B /* CheckSecurityCodeController.swift */,
+            );
+            path = Controller;
+            sourceTree = "<group>";
+        };
+        E8207929298A116700B36FC9 /* MainSession */ = {
+            isa = PBXGroup;
+            children = (
+                E820792A298A119900B36FC9 /* MainSessionDetailCell.swift */,
+                E820792C298A137700B36FC9 /* MainSessionTimeCell.swift */,
+                E820792E298A138500B36FC9 /* MainSessionAbsentCell.swift */,
+                E8207933298A22D000B36FC9 /* MainSessionInfoCell.swift */,
+                E8207935298A248100B36FC9 /* MainSessionNoInfoCell.swift */,
+            );
+            path = MainSession;
+            sourceTree = "<group>";
+        };
+        E8207930298A163400B36FC9 /* Extensions */ = {
+            isa = PBXGroup;
+            children = (
+                E8207931298A163400B36FC9 /* UIView+Extension.swift */,
+            );
+            path = Extensions;
+            sourceTree = "<group>";
+        };
+        E8D5C3E42984FC23003D1AD0 = {
+            isa = PBXGroup;
+            children = (
+                E8207930298A163400B36FC9 /* Extensions */,
+                E8207929298A116700B36FC9 /* MainSession */,
+                E8D5C3EF2984FC23003D1AD0 /* momoIOS */,
+                E8D5C3EE2984FC23003D1AD0 /* Products */,
+            );
+            sourceTree = "<group>";
+        };
+        E8D5C3EE2984FC23003D1AD0 /* Products */ = {
+            isa = PBXGroup;
+            children = (
+                E8D5C3ED2984FC23003D1AD0 /* momoIOS.app */,
+            );
+            name = Products;
+            sourceTree = "<group>";
+        };
+        E8D5C3EF2984FC23003D1AD0 /* momoIOS */ = {
+            isa = PBXGroup;
+            children = (
+                BF0408602987B3AA00F1129B /* Authentication */,
+                E8D5C3F02984FC23003D1AD0 /* AppDelegate.swift */,
+                E8D5C3F22984FC23003D1AD0 /* SceneDelegate.swift */,
+                E8D5C3F42984FC23003D1AD0 /* ViewController.swift */,
+                E83238F0298506A000DC83C2 /* MainViewController.swift */,
+                3A75FC0F298827BE00B36A46 /* MainAttendanceCodeCell.swift */,
+                3AA713C829884007006F922F /* MainAttendanceDoneCell.swift */,
+                3A5AC30F29898B330080323A /* UIButton+Extension.swift */,
+                3AA713D0298946FF006F922F /* UIColor+Extension.swift */,
+                E8D5C3F92984FC25003D1AD0 /* Assets.xcassets */,
+                E8D5C3FE2984FC25003D1AD0 /* Info.plist */,
+            );
+            path = momoIOS;
+            sourceTree = "<group>";
+        };
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		E8D5C3EC2984FC23003D1AD0 /* momoIOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = E8D5C4012984FC25003D1AD0 /* Build configuration list for PBXNativeTarget "momoIOS" */;
-			buildPhases = (
-				E8D5C3E92984FC23003D1AD0 /* Sources */,
-				E8D5C3EA2984FC23003D1AD0 /* Frameworks */,
-				E8D5C3EB2984FC23003D1AD0 /* Resources */,
-				E8D5C4042984FCCA003D1AD0 /* SwiftLint Script */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = momoIOS;
-			packageProductDependencies = (
-				E8D5C4062984FD73003D1AD0 /* SnapKit */,
-				E83238E82984FDDA00DC83C2 /* RxSwift */,
-				E83238EB2984FE0800DC83C2 /* Toast */,
-				E83238EE2984FE3200DC83C2 /* Alamofire */,
-			);
-			productName = momoIOS;
-			productReference = E8D5C3ED2984FC23003D1AD0 /* momoIOS.app */;
-			productType = "com.apple.product-type.application";
-		};
+        E8D5C3EC2984FC23003D1AD0 /* momoIOS */ = {
+            isa = PBXNativeTarget;
+            buildConfigurationList = E8D5C4012984FC25003D1AD0 /* Build configuration list for PBXNativeTarget "momoIOS" */;
+            buildPhases = (
+                E8D5C3E92984FC23003D1AD0 /* Sources */,
+                E8D5C3EA2984FC23003D1AD0 /* Frameworks */,
+                E8D5C3EB2984FC23003D1AD0 /* Resources */,
+                E8D5C4042984FCCA003D1AD0 /* SwiftLint Script */,
+            );
+            buildRules = (
+            );
+            dependencies = (
+            );
+            name = momoIOS;
+            packageProductDependencies = (
+                E8D5C4062984FD73003D1AD0 /* SnapKit */,
+                E83238E82984FDDA00DC83C2 /* RxSwift */,
+                E83238EB2984FE0800DC83C2 /* Toast */,
+                E83238EE2984FE3200DC83C2 /* Alamofire */,
+            );
+            productName = momoIOS;
+            productReference = E8D5C3ED2984FC23003D1AD0 /* momoIOS.app */;
+            productType = "com.apple.product-type.application";
+        };
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		E8D5C3E52984FC23003D1AD0 /* Project object */ = {
-			isa = PBXProject;
-			attributes = {
-				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1420;
-				LastUpgradeCheck = 1420;
-				TargetAttributes = {
-					E8D5C3EC2984FC23003D1AD0 = {
-						CreatedOnToolsVersion = 14.2;
-					};
-				};
-			};
-			buildConfigurationList = E8D5C3E82984FC23003D1AD0 /* Build configuration list for PBXProject "momoIOS" */;
-			compatibilityVersion = "Xcode 14.0";
-			developmentRegion = en;
-			hasScannedForEncodings = 0;
-			knownRegions = (
-				en,
-				Base,
-			);
-			mainGroup = E8D5C3E42984FC23003D1AD0;
-			packageReferences = (
-				E8D5C4052984FD73003D1AD0 /* XCRemoteSwiftPackageReference "SnapKit" */,
-				E83238E72984FDDA00DC83C2 /* XCRemoteSwiftPackageReference "RxSwift" */,
-				E83238EA2984FE0800DC83C2 /* XCRemoteSwiftPackageReference "Toast-Swift" */,
-				E83238ED2984FE3200DC83C2 /* XCRemoteSwiftPackageReference "Alamofire" */,
-			);
-			productRefGroup = E8D5C3EE2984FC23003D1AD0 /* Products */;
-			projectDirPath = "";
-			projectRoot = "";
-			targets = (
-				E8D5C3EC2984FC23003D1AD0 /* momoIOS */,
-			);
-		};
+        E8D5C3E52984FC23003D1AD0 /* Project object */ = {
+            isa = PBXProject;
+            attributes = {
+                BuildIndependentTargetsInParallel = 1;
+                LastSwiftUpdateCheck = 1420;
+                LastUpgradeCheck = 1420;
+                TargetAttributes = {
+                    E8D5C3EC2984FC23003D1AD0 = {
+                        CreatedOnToolsVersion = 14.2;
+                    };
+                };
+            };
+            buildConfigurationList = E8D5C3E82984FC23003D1AD0 /* Build configuration list for PBXProject "momoIOS" */;
+            compatibilityVersion = "Xcode 14.0";
+            developmentRegion = en;
+            hasScannedForEncodings = 0;
+            knownRegions = (
+                en,
+                Base,
+            );
+            mainGroup = E8D5C3E42984FC23003D1AD0;
+            packageReferences = (
+                E8D5C4052984FD73003D1AD0 /* XCRemoteSwiftPackageReference "SnapKit" */,
+                E83238E72984FDDA00DC83C2 /* XCRemoteSwiftPackageReference "RxSwift" */,
+                E83238EA2984FE0800DC83C2 /* XCRemoteSwiftPackageReference "Toast-Swift" */,
+                E83238ED2984FE3200DC83C2 /* XCRemoteSwiftPackageReference "Alamofire" */,
+            );
+            productRefGroup = E8D5C3EE2984FC23003D1AD0 /* Products */;
+            projectDirPath = "";
+            projectRoot = "";
+            targets = (
+                E8D5C3EC2984FC23003D1AD0 /* momoIOS */,
+            );
+        };
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		E8D5C3EB2984FC23003D1AD0 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				E8D5C3FA2984FC25003D1AD0 /* Assets.xcassets in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+        E8D5C3EB2984FC23003D1AD0 /* Resources */ = {
+            isa = PBXResourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+                E8D5C3FA2984FC25003D1AD0 /* Assets.xcassets in Resources */,
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		E8D5C4042984FCCA003D1AD0 /* SwiftLint Script */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "SwiftLint Script";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
+        E8D5C4042984FCCA003D1AD0 /* SwiftLint Script */ = {
+            isa = PBXShellScriptBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+            );
+            inputFileListPaths = (
+            );
+            inputPaths = (
+            );
+            name = "SwiftLint Script";
+            outputFileListPaths = (
+            );
+            outputPaths = (
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+            shellPath = /bin/sh;
+            shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+        };
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		E8D5C3E92984FC23003D1AD0 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF04086D2987E38C00F1129B /* RegistrationController.swift in Sources */,
-				E8D5C3F52984FC23003D1AD0 /* ViewController.swift in Sources */,
-				E8D5C3F12984FC23003D1AD0 /* AppDelegate.swift in Sources */,
-				BF04086F2987E70200F1129B /* CheckSecurityCodeController.swift in Sources */,
-				E8D5C3F32984FC23003D1AD0 /* SceneDelegate.swift in Sources */,
-				3A75FC10298827BE00B36A46 /* MainAttendanceCodeCell.swift in Sources */,
-				E83238F1298506A000DC83C2 /* MainViewController.swift in Sources */,
-				3A5AC31029898B330080323A /* UIButton+Extension.swift in Sources */,
-				E8207934298A22D000B36FC9 /* MainSessionInfoCell.swift in Sources */,
-				E8207932298A163400B36FC9 /* UIView+Extension.swift in Sources */,
-				E820792D298A137700B36FC9 /* MainSessionTimeCell.swift in Sources */,
-				E820792B298A119900B36FC9 /* MainSessionDetailCell.swift in Sources */,
-				E8207936298A248200B36FC9 /* MainSessionNoInfoCell.swift in Sources */,
-				3AA713D1298946FF006F922F /* UIColor+Extension.swift in Sources */,
-				3AA713C929884007006F922F /* MainAttendanceDoneCell.swift in Sources */,
-				E820792F298A138500B36FC9 /* MainSessionAbsentCell.swift in Sources */,
-				BF0408632987B3AA00F1129B /* LoginController.swift in Sources */,
-				BF04086B2987E34800F1129B /* AuthCommonConstants.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+        E8D5C3E92984FC23003D1AD0 /* Sources */ = {
+            isa = PBXSourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+                BF04086D2987E38C00F1129B /* RegistrationController.swift in Sources */,
+                E8D5C3F52984FC23003D1AD0 /* ViewController.swift in Sources */,
+                E8D5C3F12984FC23003D1AD0 /* AppDelegate.swift in Sources */,
+                BF04086F2987E70200F1129B /* CheckSecurityCodeController.swift in Sources */,
+                E8D5C3F32984FC23003D1AD0 /* SceneDelegate.swift in Sources */,
+                3A75FC10298827BE00B36A46 /* MainAttendanceCodeCell.swift in Sources */,
+                E83238F1298506A000DC83C2 /* MainViewController.swift in Sources */,
+                BF998900298BB0D3005723C7 /* InputMemberInfoController.swift in Sources */,
+                BF0408632987B3AA00F1129B /* LoginController.swift in Sources */,
+                BF04086B2987E34800F1129B /* AuthCommonConstants.swift in Sources */,
+                3A5AC31029898B330080323A /* UIButton+Extension.swift in Sources */,
+                E8207934298A22D000B36FC9 /* MainSessionInfoCell.swift in Sources */,
+                E8207932298A163400B36FC9 /* UIView+Extension.swift in Sources */,
+                E820792D298A137700B36FC9 /* MainSessionTimeCell.swift in Sources */,
+                E820792B298A119900B36FC9 /* MainSessionDetailCell.swift in Sources */,
+                E8207936298A248200B36FC9 /* MainSessionNoInfoCell.swift in Sources */,
+                3AA713D1298946FF006F922F /* UIColor+Extension.swift in Sources */,
+                3AA713C929884007006F922F /* MainAttendanceDoneCell.swift in Sources */,
+                E820792F298A138500B36FC9 /* MainSessionAbsentCell.swift in Sources */,
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
-		E8D5C3FF2984FC25003D1AD0 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
-				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
-				MTL_FAST_MATH = YES;
-				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = iphoneos;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-			};
-			name = Debug;
-		};
-		E8D5C4002984FC25003D1AD0 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				MTL_FAST_MATH = YES;
-				SDKROOT = iphoneos;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		E8D5C4022984FC25003D1AD0 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = momoIOS/Info.plist;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.teamnexters.momoIOS;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		E8D5C4032984FC25003D1AD0 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = momoIOS/Info.plist;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.teamnexters.momoIOS;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Release;
-		};
+        E8D5C3FF2984FC25003D1AD0 /* Debug */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                ALWAYS_SEARCH_USER_PATHS = NO;
+                CLANG_ANALYZER_NONNULL = YES;
+                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+                CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+                CLANG_ENABLE_MODULES = YES;
+                CLANG_ENABLE_OBJC_ARC = YES;
+                CLANG_ENABLE_OBJC_WEAK = YES;
+                CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+                CLANG_WARN_BOOL_CONVERSION = YES;
+                CLANG_WARN_COMMA = YES;
+                CLANG_WARN_CONSTANT_CONVERSION = YES;
+                CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+                CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+                CLANG_WARN_EMPTY_BODY = YES;
+                CLANG_WARN_ENUM_CONVERSION = YES;
+                CLANG_WARN_INFINITE_RECURSION = YES;
+                CLANG_WARN_INT_CONVERSION = YES;
+                CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+                CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+                CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+                CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+                CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+                CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+                CLANG_WARN_STRICT_PROTOTYPES = YES;
+                CLANG_WARN_SUSPICIOUS_MOVE = YES;
+                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+                CLANG_WARN_UNREACHABLE_CODE = YES;
+                CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+                COPY_PHASE_STRIP = NO;
+                DEBUG_INFORMATION_FORMAT = dwarf;
+                ENABLE_STRICT_OBJC_MSGSEND = YES;
+                ENABLE_TESTABILITY = YES;
+                GCC_C_LANGUAGE_STANDARD = gnu11;
+                GCC_DYNAMIC_NO_PIC = NO;
+                GCC_NO_COMMON_BLOCKS = YES;
+                GCC_OPTIMIZATION_LEVEL = 0;
+                GCC_PREPROCESSOR_DEFINITIONS = (
+                    "DEBUG=1",
+                    "$(inherited)",
+                );
+                GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+                GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+                GCC_WARN_UNDECLARED_SELECTOR = YES;
+                GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+                GCC_WARN_UNUSED_FUNCTION = YES;
+                GCC_WARN_UNUSED_VARIABLE = YES;
+                IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+                MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+                MTL_FAST_MATH = YES;
+                ONLY_ACTIVE_ARCH = YES;
+                SDKROOT = iphoneos;
+                SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+                SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+            };
+            name = Debug;
+        };
+        E8D5C4002984FC25003D1AD0 /* Release */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                ALWAYS_SEARCH_USER_PATHS = NO;
+                CLANG_ANALYZER_NONNULL = YES;
+                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+                CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+                CLANG_ENABLE_MODULES = YES;
+                CLANG_ENABLE_OBJC_ARC = YES;
+                CLANG_ENABLE_OBJC_WEAK = YES;
+                CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+                CLANG_WARN_BOOL_CONVERSION = YES;
+                CLANG_WARN_COMMA = YES;
+                CLANG_WARN_CONSTANT_CONVERSION = YES;
+                CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+                CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+                CLANG_WARN_EMPTY_BODY = YES;
+                CLANG_WARN_ENUM_CONVERSION = YES;
+                CLANG_WARN_INFINITE_RECURSION = YES;
+                CLANG_WARN_INT_CONVERSION = YES;
+                CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+                CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+                CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+                CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+                CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+                CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+                CLANG_WARN_STRICT_PROTOTYPES = YES;
+                CLANG_WARN_SUSPICIOUS_MOVE = YES;
+                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+                CLANG_WARN_UNREACHABLE_CODE = YES;
+                CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+                COPY_PHASE_STRIP = NO;
+                DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+                ENABLE_NS_ASSERTIONS = NO;
+                ENABLE_STRICT_OBJC_MSGSEND = YES;
+                GCC_C_LANGUAGE_STANDARD = gnu11;
+                GCC_NO_COMMON_BLOCKS = YES;
+                GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+                GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+                GCC_WARN_UNDECLARED_SELECTOR = YES;
+                GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+                GCC_WARN_UNUSED_FUNCTION = YES;
+                GCC_WARN_UNUSED_VARIABLE = YES;
+                IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+                MTL_ENABLE_DEBUG_INFO = NO;
+                MTL_FAST_MATH = YES;
+                SDKROOT = iphoneos;
+                SWIFT_COMPILATION_MODE = wholemodule;
+                SWIFT_OPTIMIZATION_LEVEL = "-O";
+                VALIDATE_PRODUCT = YES;
+            };
+            name = Release;
+        };
+        E8D5C4022984FC25003D1AD0 /* Debug */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+                ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+                CODE_SIGN_STYLE = Automatic;
+                CURRENT_PROJECT_VERSION = 1;
+                GENERATE_INFOPLIST_FILE = YES;
+                INFOPLIST_FILE = momoIOS/Info.plist;
+                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+                INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+                IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+                LD_RUNPATH_SEARCH_PATHS = (
+                    "$(inherited)",
+                    "@executable_path/Frameworks",
+                );
+                MARKETING_VERSION = 1.0;
+                PRODUCT_BUNDLE_IDENTIFIER = com.teamnexters.momoIOS;
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                SWIFT_EMIT_LOC_STRINGS = YES;
+                SWIFT_VERSION = 5.0;
+                TARGETED_DEVICE_FAMILY = "1,2";
+            };
+            name = Debug;
+        };
+        E8D5C4032984FC25003D1AD0 /* Release */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+                ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+                CODE_SIGN_STYLE = Automatic;
+                CURRENT_PROJECT_VERSION = 1;
+                GENERATE_INFOPLIST_FILE = YES;
+                INFOPLIST_FILE = momoIOS/Info.plist;
+                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+                INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+                IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+                LD_RUNPATH_SEARCH_PATHS = (
+                    "$(inherited)",
+                    "@executable_path/Frameworks",
+                );
+                MARKETING_VERSION = 1.0;
+                PRODUCT_BUNDLE_IDENTIFIER = com.teamnexters.momoIOS;
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                SWIFT_EMIT_LOC_STRINGS = YES;
+                SWIFT_VERSION = 5.0;
+                TARGETED_DEVICE_FAMILY = "1,2";
+            };
+            name = Release;
+        };
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		E8D5C3E82984FC23003D1AD0 /* Build configuration list for PBXProject "momoIOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				E8D5C3FF2984FC25003D1AD0 /* Debug */,
-				E8D5C4002984FC25003D1AD0 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		E8D5C4012984FC25003D1AD0 /* Build configuration list for PBXNativeTarget "momoIOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				E8D5C4022984FC25003D1AD0 /* Debug */,
-				E8D5C4032984FC25003D1AD0 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
+        E8D5C3E82984FC23003D1AD0 /* Build configuration list for PBXProject "momoIOS" */ = {
+            isa = XCConfigurationList;
+            buildConfigurations = (
+                E8D5C3FF2984FC25003D1AD0 /* Debug */,
+                E8D5C4002984FC25003D1AD0 /* Release */,
+            );
+            defaultConfigurationIsVisible = 0;
+            defaultConfigurationName = Release;
+        };
+        E8D5C4012984FC25003D1AD0 /* Build configuration list for PBXNativeTarget "momoIOS" */ = {
+            isa = XCConfigurationList;
+            buildConfigurations = (
+                E8D5C4022984FC25003D1AD0 /* Debug */,
+                E8D5C4032984FC25003D1AD0 /* Release */,
+            );
+            defaultConfigurationIsVisible = 0;
+            defaultConfigurationName = Release;
+        };
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		E83238E72984FDDA00DC83C2 /* XCRemoteSwiftPackageReference "RxSwift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/ReactiveX/RxSwift";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 6.0.0;
-			};
-		};
-		E83238EA2984FE0800DC83C2 /* XCRemoteSwiftPackageReference "Toast-Swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/scalessec/Toast-Swift";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 5.0.0;
-			};
-		};
-		E83238ED2984FE3200DC83C2 /* XCRemoteSwiftPackageReference "Alamofire" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Alamofire/Alamofire";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 5.0.0;
-			};
-		};
-		E8D5C4052984FD73003D1AD0 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/SnapKit/SnapKit";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 5.0.0;
-			};
-		};
+        E83238E72984FDDA00DC83C2 /* XCRemoteSwiftPackageReference "RxSwift" */ = {
+            isa = XCRemoteSwiftPackageReference;
+            repositoryURL = "https://github.com/ReactiveX/RxSwift";
+            requirement = {
+                kind = upToNextMajorVersion;
+                minimumVersion = 6.0.0;
+            };
+        };
+        E83238EA2984FE0800DC83C2 /* XCRemoteSwiftPackageReference "Toast-Swift" */ = {
+            isa = XCRemoteSwiftPackageReference;
+            repositoryURL = "https://github.com/scalessec/Toast-Swift";
+            requirement = {
+                kind = upToNextMajorVersion;
+                minimumVersion = 5.0.0;
+            };
+        };
+        E83238ED2984FE3200DC83C2 /* XCRemoteSwiftPackageReference "Alamofire" */ = {
+            isa = XCRemoteSwiftPackageReference;
+            repositoryURL = "https://github.com/Alamofire/Alamofire";
+            requirement = {
+                kind = upToNextMajorVersion;
+                minimumVersion = 5.0.0;
+            };
+        };
+        E8D5C4052984FD73003D1AD0 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
+            isa = XCRemoteSwiftPackageReference;
+            repositoryURL = "https://github.com/SnapKit/SnapKit";
+            requirement = {
+                kind = upToNextMajorVersion;
+                minimumVersion = 5.0.0;
+            };
+        };
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		E83238E82984FDDA00DC83C2 /* RxSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E83238E72984FDDA00DC83C2 /* XCRemoteSwiftPackageReference "RxSwift" */;
-			productName = RxSwift;
-		};
-		E83238EB2984FE0800DC83C2 /* Toast */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E83238EA2984FE0800DC83C2 /* XCRemoteSwiftPackageReference "Toast-Swift" */;
-			productName = Toast;
-		};
-		E83238EE2984FE3200DC83C2 /* Alamofire */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E83238ED2984FE3200DC83C2 /* XCRemoteSwiftPackageReference "Alamofire" */;
-			productName = Alamofire;
-		};
-		E8D5C4062984FD73003D1AD0 /* SnapKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E8D5C4052984FD73003D1AD0 /* XCRemoteSwiftPackageReference "SnapKit" */;
-			productName = SnapKit;
-		};
+        E83238E82984FDDA00DC83C2 /* RxSwift */ = {
+            isa = XCSwiftPackageProductDependency;
+            package = E83238E72984FDDA00DC83C2 /* XCRemoteSwiftPackageReference "RxSwift" */;
+            productName = RxSwift;
+        };
+        E83238EB2984FE0800DC83C2 /* Toast */ = {
+            isa = XCSwiftPackageProductDependency;
+            package = E83238EA2984FE0800DC83C2 /* XCRemoteSwiftPackageReference "Toast-Swift" */;
+            productName = Toast;
+        };
+        E83238EE2984FE3200DC83C2 /* Alamofire */ = {
+            isa = XCSwiftPackageProductDependency;
+            package = E83238ED2984FE3200DC83C2 /* XCRemoteSwiftPackageReference "Alamofire" */;
+            productName = Alamofire;
+        };
+        E8D5C4062984FD73003D1AD0 /* SnapKit */ = {
+            isa = XCSwiftPackageProductDependency;
+            package = E8D5C4052984FD73003D1AD0 /* XCRemoteSwiftPackageReference "SnapKit" */;
+            productName = SnapKit;
+        };
 /* End XCSwiftPackageProductDependency section */
-	};
-	rootObject = E8D5C3E52984FC23003D1AD0 /* Project object */;
+    };
+    rootObject = E8D5C3E52984FC23003D1AD0 /* Project object */;
 }

--- a/momoIOS.xcodeproj/project.pbxproj
+++ b/momoIOS.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		E8207932298A163400B36FC9 /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8207931298A163400B36FC9 /* UIView+Extension.swift */; };
 		E8207934298A22D000B36FC9 /* MainSessionInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8207933298A22D000B36FC9 /* MainSessionInfoCell.swift */; };
 		E8207936298A248200B36FC9 /* MainSessionNoInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8207935298A248100B36FC9 /* MainSessionNoInfoCell.swift */; };
+		BF0408632987B3AA00F1129B /* LoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0408622987B3AA00F1129B /* LoginController.swift */; };
 		E83238E92984FDDA00DC83C2 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E83238E82984FDDA00DC83C2 /* RxSwift */; };
 		E83238EC2984FE0800DC83C2 /* Toast in Frameworks */ = {isa = PBXBuildFile; productRef = E83238EB2984FE0800DC83C2 /* Toast */; };
 		E83238EF2984FE3200DC83C2 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = E83238EE2984FE3200DC83C2 /* Alamofire */; };
@@ -39,6 +40,7 @@
 		E8207931298A163400B36FC9 /* UIView+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
 		E8207933298A22D000B36FC9 /* MainSessionInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSessionInfoCell.swift; sourceTree = "<group>"; };
 		E8207935298A248100B36FC9 /* MainSessionNoInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSessionNoInfoCell.swift; sourceTree = "<group>"; };
+		BF0408622987B3AA00F1129B /* LoginController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginController.swift; sourceTree = "<group>"; };
 		E83238F0298506A000DC83C2 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		E8D5C3ED2984FC23003D1AD0 /* momoIOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = momoIOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E8D5C3F02984FC23003D1AD0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -81,6 +83,20 @@
 				E8207931298A163400B36FC9 /* UIView+Extension.swift */,
 			);
 			path = Extensions;
+		BF0408602987B3AA00F1129B /* Authentication */ = {
+			isa = PBXGroup;
+			children = (
+				BF0408612987B3AA00F1129B /* Controller */,
+			);
+			path = Authentication;
+			sourceTree = "<group>";
+		};
+		BF0408612987B3AA00F1129B /* Controller */ = {
+			isa = PBXGroup;
+			children = (
+				BF0408622987B3AA00F1129B /* LoginController.swift */,
+			);
+			path = Controller;
 			sourceTree = "<group>";
 		};
 		E8D5C3E42984FC23003D1AD0 = {
@@ -104,6 +120,7 @@
 		E8D5C3EF2984FC23003D1AD0 /* momoIOS */ = {
 			isa = PBXGroup;
 			children = (
+				BF0408602987B3AA00F1129B /* Authentication */,
 				E8D5C3F02984FC23003D1AD0 /* AppDelegate.swift */,
 				E8D5C3F22984FC23003D1AD0 /* SceneDelegate.swift */,
 				E8D5C3F42984FC23003D1AD0 /* ViewController.swift */,
@@ -235,6 +252,7 @@
 				3AA713D1298946FF006F922F /* UIColor+Extension.swift in Sources */,
 				3AA713C929884007006F922F /* MainAttendanceDoneCell.swift in Sources */,
 				E820792F298A138500B36FC9 /* MainSessionAbsentCell.swift in Sources */,
+				BF0408632987B3AA00F1129B /* LoginController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/momoIOS.xcodeproj/project.pbxproj
+++ b/momoIOS.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		E8207934298A22D000B36FC9 /* MainSessionInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8207933298A22D000B36FC9 /* MainSessionInfoCell.swift */; };
 		E8207936298A248200B36FC9 /* MainSessionNoInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8207935298A248100B36FC9 /* MainSessionNoInfoCell.swift */; };
 		BF0408632987B3AA00F1129B /* LoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0408622987B3AA00F1129B /* LoginController.swift */; };
+		BF04086B2987E34800F1129B /* AuthCommonConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086A2987E34800F1129B /* AuthCommonConstants.swift */; };
+		BF04086D2987E38C00F1129B /* RegistrationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086C2987E38C00F1129B /* RegistrationController.swift */; };
 		E83238E92984FDDA00DC83C2 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E83238E82984FDDA00DC83C2 /* RxSwift */; };
 		E83238EC2984FE0800DC83C2 /* Toast in Frameworks */ = {isa = PBXBuildFile; productRef = E83238EB2984FE0800DC83C2 /* Toast */; };
 		E83238EF2984FE3200DC83C2 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = E83238EE2984FE3200DC83C2 /* Alamofire */; };
@@ -41,6 +43,8 @@
 		E8207933298A22D000B36FC9 /* MainSessionInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSessionInfoCell.swift; sourceTree = "<group>"; };
 		E8207935298A248100B36FC9 /* MainSessionNoInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSessionNoInfoCell.swift; sourceTree = "<group>"; };
 		BF0408622987B3AA00F1129B /* LoginController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginController.swift; sourceTree = "<group>"; };
+		BF04086A2987E34800F1129B /* AuthCommonConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCommonConstants.swift; sourceTree = "<group>"; };
+		BF04086C2987E38C00F1129B /* RegistrationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationController.swift; sourceTree = "<group>"; };
 		E83238F0298506A000DC83C2 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		E8D5C3ED2984FC23003D1AD0 /* momoIOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = momoIOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E8D5C3F02984FC23003D1AD0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -95,6 +99,8 @@
 			isa = PBXGroup;
 			children = (
 				BF0408622987B3AA00F1129B /* LoginController.swift */,
+				BF04086C2987E38C00F1129B /* RegistrationController.swift */,
+				BF04086A2987E34800F1129B /* AuthCommonConstants.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -238,6 +244,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BF04086D2987E38C00F1129B /* RegistrationController.swift in Sources */,
 				E8D5C3F52984FC23003D1AD0 /* ViewController.swift in Sources */,
 				E8D5C3F12984FC23003D1AD0 /* AppDelegate.swift in Sources */,
 				E8D5C3F32984FC23003D1AD0 /* SceneDelegate.swift in Sources */,
@@ -253,6 +260,7 @@
 				3AA713C929884007006F922F /* MainAttendanceDoneCell.swift in Sources */,
 				E820792F298A138500B36FC9 /* MainSessionAbsentCell.swift in Sources */,
 				BF0408632987B3AA00F1129B /* LoginController.swift in Sources */,
+				BF04086B2987E34800F1129B /* AuthCommonConstants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/momoIOS.xcodeproj/project.pbxproj
+++ b/momoIOS.xcodeproj/project.pbxproj
@@ -1,530 +1,530 @@
 // !$*UTF8*$!
 {
-    archiveVersion = 1;
-    classes = {
-    };
-    objectVersion = 56;
-    objects = {
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
 
 /* Begin PBXBuildFile section */
-        3A5AC31029898B330080323A /* UIButton+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5AC30F29898B330080323A /* UIButton+Extension.swift */; };
-        3A75FC10298827BE00B36A46 /* MainAttendanceCodeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A75FC0F298827BE00B36A46 /* MainAttendanceCodeCell.swift */; };
-        3AA713C929884007006F922F /* MainAttendanceDoneCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA713C829884007006F922F /* MainAttendanceDoneCell.swift */; };
-        3AA713D1298946FF006F922F /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA713D0298946FF006F922F /* UIColor+Extension.swift */; };
-        BF0408632987B3AA00F1129B /* LoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0408622987B3AA00F1129B /* LoginController.swift */; };
-        BF04086B2987E34800F1129B /* AuthCommonConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086A2987E34800F1129B /* AuthCommonConstants.swift */; };
-        BF04086D2987E38C00F1129B /* RegistrationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086C2987E38C00F1129B /* RegistrationController.swift */; };
-        BF04086F2987E70200F1129B /* CheckSecurityCodeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086E2987E70200F1129B /* CheckSecurityCodeController.swift */; };
-        BF998900298BB0D3005723C7 /* InputMemberInfoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9988FF298BB0D3005723C7 /* InputMemberInfoController.swift */; };
-        E820792B298A119900B36FC9 /* MainSessionDetailCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E820792A298A119900B36FC9 /* MainSessionDetailCell.swift */; };
-        E820792D298A137700B36FC9 /* MainSessionTimeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E820792C298A137700B36FC9 /* MainSessionTimeCell.swift */; };
-        E820792F298A138500B36FC9 /* MainSessionAbsentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E820792E298A138500B36FC9 /* MainSessionAbsentCell.swift */; };
-        E8207932298A163400B36FC9 /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8207931298A163400B36FC9 /* UIView+Extension.swift */; };
-        E8207934298A22D000B36FC9 /* MainSessionInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8207933298A22D000B36FC9 /* MainSessionInfoCell.swift */; };
-        E8207936298A248200B36FC9 /* MainSessionNoInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8207935298A248100B36FC9 /* MainSessionNoInfoCell.swift */; };
-        E83238E92984FDDA00DC83C2 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E83238E82984FDDA00DC83C2 /* RxSwift */; };
-        E83238EC2984FE0800DC83C2 /* Toast in Frameworks */ = {isa = PBXBuildFile; productRef = E83238EB2984FE0800DC83C2 /* Toast */; };
-        E83238EF2984FE3200DC83C2 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = E83238EE2984FE3200DC83C2 /* Alamofire */; };
-        E83238F1298506A000DC83C2 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E83238F0298506A000DC83C2 /* MainViewController.swift */; };
-        E8D5C3F12984FC23003D1AD0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D5C3F02984FC23003D1AD0 /* AppDelegate.swift */; };
-        E8D5C3F32984FC23003D1AD0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D5C3F22984FC23003D1AD0 /* SceneDelegate.swift */; };
-        E8D5C3F52984FC23003D1AD0 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D5C3F42984FC23003D1AD0 /* ViewController.swift */; };
-        E8D5C3FA2984FC25003D1AD0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E8D5C3F92984FC25003D1AD0 /* Assets.xcassets */; };
-        E8D5C4072984FD73003D1AD0 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = E8D5C4062984FD73003D1AD0 /* SnapKit */; };
+		3A5AC31029898B330080323A /* UIButton+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5AC30F29898B330080323A /* UIButton+Extension.swift */; };
+		3A75FC10298827BE00B36A46 /* MainAttendanceCodeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A75FC0F298827BE00B36A46 /* MainAttendanceCodeCell.swift */; };
+		3AA713C929884007006F922F /* MainAttendanceDoneCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA713C829884007006F922F /* MainAttendanceDoneCell.swift */; };
+		3AA713D1298946FF006F922F /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA713D0298946FF006F922F /* UIColor+Extension.swift */; };
+		BF0408632987B3AA00F1129B /* LoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0408622987B3AA00F1129B /* LoginController.swift */; };
+		BF04086B2987E34800F1129B /* AuthCommonConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086A2987E34800F1129B /* AuthCommonConstants.swift */; };
+		BF04086D2987E38C00F1129B /* RegistrationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086C2987E38C00F1129B /* RegistrationController.swift */; };
+		BF04086F2987E70200F1129B /* CheckSecurityCodeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086E2987E70200F1129B /* CheckSecurityCodeController.swift */; };
+		BF998900298BB0D3005723C7 /* InputMemberInfoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9988FF298BB0D3005723C7 /* InputMemberInfoController.swift */; };
+		E820792B298A119900B36FC9 /* MainSessionDetailCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E820792A298A119900B36FC9 /* MainSessionDetailCell.swift */; };
+		E820792D298A137700B36FC9 /* MainSessionTimeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E820792C298A137700B36FC9 /* MainSessionTimeCell.swift */; };
+		E820792F298A138500B36FC9 /* MainSessionAbsentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E820792E298A138500B36FC9 /* MainSessionAbsentCell.swift */; };
+		E8207932298A163400B36FC9 /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8207931298A163400B36FC9 /* UIView+Extension.swift */; };
+		E8207934298A22D000B36FC9 /* MainSessionInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8207933298A22D000B36FC9 /* MainSessionInfoCell.swift */; };
+		E8207936298A248200B36FC9 /* MainSessionNoInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8207935298A248100B36FC9 /* MainSessionNoInfoCell.swift */; };
+		E83238E92984FDDA00DC83C2 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E83238E82984FDDA00DC83C2 /* RxSwift */; };
+		E83238EC2984FE0800DC83C2 /* Toast in Frameworks */ = {isa = PBXBuildFile; productRef = E83238EB2984FE0800DC83C2 /* Toast */; };
+		E83238EF2984FE3200DC83C2 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = E83238EE2984FE3200DC83C2 /* Alamofire */; };
+		E83238F1298506A000DC83C2 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E83238F0298506A000DC83C2 /* MainViewController.swift */; };
+		E8D5C3F12984FC23003D1AD0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D5C3F02984FC23003D1AD0 /* AppDelegate.swift */; };
+		E8D5C3F32984FC23003D1AD0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D5C3F22984FC23003D1AD0 /* SceneDelegate.swift */; };
+		E8D5C3F52984FC23003D1AD0 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D5C3F42984FC23003D1AD0 /* ViewController.swift */; };
+		E8D5C3FA2984FC25003D1AD0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E8D5C3F92984FC25003D1AD0 /* Assets.xcassets */; };
+		E8D5C4072984FD73003D1AD0 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = E8D5C4062984FD73003D1AD0 /* SnapKit */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-        3A5AC30F29898B330080323A /* UIButton+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Extension.swift"; sourceTree = "<group>"; };
-        3A75FC0F298827BE00B36A46 /* MainAttendanceCodeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainAttendanceCodeCell.swift; sourceTree = "<group>"; };
-        3AA713C829884007006F922F /* MainAttendanceDoneCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainAttendanceDoneCell.swift; sourceTree = "<group>"; };
-        3AA713D0298946FF006F922F /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
-        BF0408622987B3AA00F1129B /* LoginController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginController.swift; sourceTree = "<group>"; };
-        BF04086A2987E34800F1129B /* AuthCommonConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCommonConstants.swift; sourceTree = "<group>"; };
-        BF04086C2987E38C00F1129B /* RegistrationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationController.swift; sourceTree = "<group>"; };
-        BF04086E2987E70200F1129B /* CheckSecurityCodeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckSecurityCodeController.swift; sourceTree = "<group>"; };
-        BF9988FF298BB0D3005723C7 /* InputMemberInfoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputMemberInfoController.swift; sourceTree = "<group>"; };
-        E820792A298A119900B36FC9 /* MainSessionDetailCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSessionDetailCell.swift; sourceTree = "<group>"; };
-        E820792C298A137700B36FC9 /* MainSessionTimeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSessionTimeCell.swift; sourceTree = "<group>"; };
-        E820792E298A138500B36FC9 /* MainSessionAbsentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSessionAbsentCell.swift; sourceTree = "<group>"; };
-        E8207931298A163400B36FC9 /* UIView+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
-        E8207933298A22D000B36FC9 /* MainSessionInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSessionInfoCell.swift; sourceTree = "<group>"; };
-        E8207935298A248100B36FC9 /* MainSessionNoInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSessionNoInfoCell.swift; sourceTree = "<group>"; };
-        E83238F0298506A000DC83C2 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
-        E8D5C3ED2984FC23003D1AD0 /* momoIOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = momoIOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
-        E8D5C3F02984FC23003D1AD0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-        E8D5C3F22984FC23003D1AD0 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-        E8D5C3F42984FC23003D1AD0 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
-        E8D5C3F92984FC25003D1AD0 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-        E8D5C3FE2984FC25003D1AD0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3A5AC30F29898B330080323A /* UIButton+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Extension.swift"; sourceTree = "<group>"; };
+		3A75FC0F298827BE00B36A46 /* MainAttendanceCodeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainAttendanceCodeCell.swift; sourceTree = "<group>"; };
+		3AA713C829884007006F922F /* MainAttendanceDoneCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainAttendanceDoneCell.swift; sourceTree = "<group>"; };
+		3AA713D0298946FF006F922F /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
+		BF0408622987B3AA00F1129B /* LoginController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginController.swift; sourceTree = "<group>"; };
+		BF04086A2987E34800F1129B /* AuthCommonConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCommonConstants.swift; sourceTree = "<group>"; };
+		BF04086C2987E38C00F1129B /* RegistrationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationController.swift; sourceTree = "<group>"; };
+		BF04086E2987E70200F1129B /* CheckSecurityCodeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckSecurityCodeController.swift; sourceTree = "<group>"; };
+		BF9988FF298BB0D3005723C7 /* InputMemberInfoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputMemberInfoController.swift; sourceTree = "<group>"; };
+		E820792A298A119900B36FC9 /* MainSessionDetailCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSessionDetailCell.swift; sourceTree = "<group>"; };
+		E820792C298A137700B36FC9 /* MainSessionTimeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSessionTimeCell.swift; sourceTree = "<group>"; };
+		E820792E298A138500B36FC9 /* MainSessionAbsentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSessionAbsentCell.swift; sourceTree = "<group>"; };
+		E8207931298A163400B36FC9 /* UIView+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
+		E8207933298A22D000B36FC9 /* MainSessionInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSessionInfoCell.swift; sourceTree = "<group>"; };
+		E8207935298A248100B36FC9 /* MainSessionNoInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSessionNoInfoCell.swift; sourceTree = "<group>"; };
+		E83238F0298506A000DC83C2 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
+		E8D5C3ED2984FC23003D1AD0 /* momoIOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = momoIOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		E8D5C3F02984FC23003D1AD0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		E8D5C3F22984FC23003D1AD0 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		E8D5C3F42984FC23003D1AD0 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		E8D5C3F92984FC25003D1AD0 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		E8D5C3FE2984FC25003D1AD0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-        E8D5C3EA2984FC23003D1AD0 /* Frameworks */ = {
-            isa = PBXFrameworksBuildPhase;
-            buildActionMask = 2147483647;
-            files = (
-                E83238EC2984FE0800DC83C2 /* Toast in Frameworks */,
-                E83238EF2984FE3200DC83C2 /* Alamofire in Frameworks */,
-                E83238E92984FDDA00DC83C2 /* RxSwift in Frameworks */,
-                E8D5C4072984FD73003D1AD0 /* SnapKit in Frameworks */,
-            );
-            runOnlyForDeploymentPostprocessing = 0;
-        };
+		E8D5C3EA2984FC23003D1AD0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E83238EC2984FE0800DC83C2 /* Toast in Frameworks */,
+				E83238EF2984FE3200DC83C2 /* Alamofire in Frameworks */,
+				E83238E92984FDDA00DC83C2 /* RxSwift in Frameworks */,
+				E8D5C4072984FD73003D1AD0 /* SnapKit in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-        BF0408602987B3AA00F1129B /* Authentication */ = {
-            isa = PBXGroup;
-            children = (
-                BF0408612987B3AA00F1129B /* Controller */,
-            );
-            path = Authentication;
-            sourceTree = "<group>";
-        };
-        BF0408612987B3AA00F1129B /* Controller */ = {
-            isa = PBXGroup;
-            children = (
-                BF0408622987B3AA00F1129B /* LoginController.swift */,
-                BF04086C2987E38C00F1129B /* RegistrationController.swift */,
-                BF9988FF298BB0D3005723C7 /* InputMemberInfoController.swift */,
-                BF04086A2987E34800F1129B /* AuthCommonConstants.swift */,
-                BF04086E2987E70200F1129B /* CheckSecurityCodeController.swift */,
-            );
-            path = Controller;
-            sourceTree = "<group>";
-        };
-        E8207929298A116700B36FC9 /* MainSession */ = {
-            isa = PBXGroup;
-            children = (
-                E820792A298A119900B36FC9 /* MainSessionDetailCell.swift */,
-                E820792C298A137700B36FC9 /* MainSessionTimeCell.swift */,
-                E820792E298A138500B36FC9 /* MainSessionAbsentCell.swift */,
-                E8207933298A22D000B36FC9 /* MainSessionInfoCell.swift */,
-                E8207935298A248100B36FC9 /* MainSessionNoInfoCell.swift */,
-            );
-            path = MainSession;
-            sourceTree = "<group>";
-        };
-        E8207930298A163400B36FC9 /* Extensions */ = {
-            isa = PBXGroup;
-            children = (
-                E8207931298A163400B36FC9 /* UIView+Extension.swift */,
-            );
-            path = Extensions;
-            sourceTree = "<group>";
-        };
-        E8D5C3E42984FC23003D1AD0 = {
-            isa = PBXGroup;
-            children = (
-                E8207930298A163400B36FC9 /* Extensions */,
-                E8207929298A116700B36FC9 /* MainSession */,
-                E8D5C3EF2984FC23003D1AD0 /* momoIOS */,
-                E8D5C3EE2984FC23003D1AD0 /* Products */,
-            );
-            sourceTree = "<group>";
-        };
-        E8D5C3EE2984FC23003D1AD0 /* Products */ = {
-            isa = PBXGroup;
-            children = (
-                E8D5C3ED2984FC23003D1AD0 /* momoIOS.app */,
-            );
-            name = Products;
-            sourceTree = "<group>";
-        };
-        E8D5C3EF2984FC23003D1AD0 /* momoIOS */ = {
-            isa = PBXGroup;
-            children = (
-                BF0408602987B3AA00F1129B /* Authentication */,
-                E8D5C3F02984FC23003D1AD0 /* AppDelegate.swift */,
-                E8D5C3F22984FC23003D1AD0 /* SceneDelegate.swift */,
-                E8D5C3F42984FC23003D1AD0 /* ViewController.swift */,
-                E83238F0298506A000DC83C2 /* MainViewController.swift */,
-                3A75FC0F298827BE00B36A46 /* MainAttendanceCodeCell.swift */,
-                3AA713C829884007006F922F /* MainAttendanceDoneCell.swift */,
-                3A5AC30F29898B330080323A /* UIButton+Extension.swift */,
-                3AA713D0298946FF006F922F /* UIColor+Extension.swift */,
-                E8D5C3F92984FC25003D1AD0 /* Assets.xcassets */,
-                E8D5C3FE2984FC25003D1AD0 /* Info.plist */,
-            );
-            path = momoIOS;
-            sourceTree = "<group>";
-        };
+		BF0408602987B3AA00F1129B /* Authentication */ = {
+			isa = PBXGroup;
+			children = (
+				BF0408612987B3AA00F1129B /* Controller */,
+			);
+			path = Authentication;
+			sourceTree = "<group>";
+		};
+		BF0408612987B3AA00F1129B /* Controller */ = {
+			isa = PBXGroup;
+			children = (
+				BF0408622987B3AA00F1129B /* LoginController.swift */,
+				BF04086C2987E38C00F1129B /* RegistrationController.swift */,
+				BF9988FF298BB0D3005723C7 /* InputMemberInfoController.swift */,
+				BF04086A2987E34800F1129B /* AuthCommonConstants.swift */,
+				BF04086E2987E70200F1129B /* CheckSecurityCodeController.swift */,
+			);
+			path = Controller;
+			sourceTree = "<group>";
+		};
+		E8207929298A116700B36FC9 /* MainSession */ = {
+			isa = PBXGroup;
+			children = (
+				E820792A298A119900B36FC9 /* MainSessionDetailCell.swift */,
+				E820792C298A137700B36FC9 /* MainSessionTimeCell.swift */,
+				E820792E298A138500B36FC9 /* MainSessionAbsentCell.swift */,
+				E8207933298A22D000B36FC9 /* MainSessionInfoCell.swift */,
+				E8207935298A248100B36FC9 /* MainSessionNoInfoCell.swift */,
+			);
+			path = MainSession;
+			sourceTree = "<group>";
+		};
+		E8207930298A163400B36FC9 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				E8207931298A163400B36FC9 /* UIView+Extension.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		E8D5C3E42984FC23003D1AD0 = {
+			isa = PBXGroup;
+			children = (
+				E8207930298A163400B36FC9 /* Extensions */,
+				E8207929298A116700B36FC9 /* MainSession */,
+				E8D5C3EF2984FC23003D1AD0 /* momoIOS */,
+				E8D5C3EE2984FC23003D1AD0 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		E8D5C3EE2984FC23003D1AD0 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E8D5C3ED2984FC23003D1AD0 /* momoIOS.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		E8D5C3EF2984FC23003D1AD0 /* momoIOS */ = {
+			isa = PBXGroup;
+			children = (
+				BF0408602987B3AA00F1129B /* Authentication */,
+				E8D5C3F02984FC23003D1AD0 /* AppDelegate.swift */,
+				E8D5C3F22984FC23003D1AD0 /* SceneDelegate.swift */,
+				E8D5C3F42984FC23003D1AD0 /* ViewController.swift */,
+				E83238F0298506A000DC83C2 /* MainViewController.swift */,
+				3A75FC0F298827BE00B36A46 /* MainAttendanceCodeCell.swift */,
+				3AA713C829884007006F922F /* MainAttendanceDoneCell.swift */,
+				3A5AC30F29898B330080323A /* UIButton+Extension.swift */,
+				3AA713D0298946FF006F922F /* UIColor+Extension.swift */,
+				E8D5C3F92984FC25003D1AD0 /* Assets.xcassets */,
+				E8D5C3FE2984FC25003D1AD0 /* Info.plist */,
+			);
+			path = momoIOS;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-        E8D5C3EC2984FC23003D1AD0 /* momoIOS */ = {
-            isa = PBXNativeTarget;
-            buildConfigurationList = E8D5C4012984FC25003D1AD0 /* Build configuration list for PBXNativeTarget "momoIOS" */;
-            buildPhases = (
-                E8D5C3E92984FC23003D1AD0 /* Sources */,
-                E8D5C3EA2984FC23003D1AD0 /* Frameworks */,
-                E8D5C3EB2984FC23003D1AD0 /* Resources */,
-                E8D5C4042984FCCA003D1AD0 /* SwiftLint Script */,
-            );
-            buildRules = (
-            );
-            dependencies = (
-            );
-            name = momoIOS;
-            packageProductDependencies = (
-                E8D5C4062984FD73003D1AD0 /* SnapKit */,
-                E83238E82984FDDA00DC83C2 /* RxSwift */,
-                E83238EB2984FE0800DC83C2 /* Toast */,
-                E83238EE2984FE3200DC83C2 /* Alamofire */,
-            );
-            productName = momoIOS;
-            productReference = E8D5C3ED2984FC23003D1AD0 /* momoIOS.app */;
-            productType = "com.apple.product-type.application";
-        };
+		E8D5C3EC2984FC23003D1AD0 /* momoIOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E8D5C4012984FC25003D1AD0 /* Build configuration list for PBXNativeTarget "momoIOS" */;
+			buildPhases = (
+				E8D5C3E92984FC23003D1AD0 /* Sources */,
+				E8D5C3EA2984FC23003D1AD0 /* Frameworks */,
+				E8D5C3EB2984FC23003D1AD0 /* Resources */,
+				E8D5C4042984FCCA003D1AD0 /* SwiftLint Script */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = momoIOS;
+			packageProductDependencies = (
+				E8D5C4062984FD73003D1AD0 /* SnapKit */,
+				E83238E82984FDDA00DC83C2 /* RxSwift */,
+				E83238EB2984FE0800DC83C2 /* Toast */,
+				E83238EE2984FE3200DC83C2 /* Alamofire */,
+			);
+			productName = momoIOS;
+			productReference = E8D5C3ED2984FC23003D1AD0 /* momoIOS.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-        E8D5C3E52984FC23003D1AD0 /* Project object */ = {
-            isa = PBXProject;
-            attributes = {
-                BuildIndependentTargetsInParallel = 1;
-                LastSwiftUpdateCheck = 1420;
-                LastUpgradeCheck = 1420;
-                TargetAttributes = {
-                    E8D5C3EC2984FC23003D1AD0 = {
-                        CreatedOnToolsVersion = 14.2;
-                    };
-                };
-            };
-            buildConfigurationList = E8D5C3E82984FC23003D1AD0 /* Build configuration list for PBXProject "momoIOS" */;
-            compatibilityVersion = "Xcode 14.0";
-            developmentRegion = en;
-            hasScannedForEncodings = 0;
-            knownRegions = (
-                en,
-                Base,
-            );
-            mainGroup = E8D5C3E42984FC23003D1AD0;
-            packageReferences = (
-                E8D5C4052984FD73003D1AD0 /* XCRemoteSwiftPackageReference "SnapKit" */,
-                E83238E72984FDDA00DC83C2 /* XCRemoteSwiftPackageReference "RxSwift" */,
-                E83238EA2984FE0800DC83C2 /* XCRemoteSwiftPackageReference "Toast-Swift" */,
-                E83238ED2984FE3200DC83C2 /* XCRemoteSwiftPackageReference "Alamofire" */,
-            );
-            productRefGroup = E8D5C3EE2984FC23003D1AD0 /* Products */;
-            projectDirPath = "";
-            projectRoot = "";
-            targets = (
-                E8D5C3EC2984FC23003D1AD0 /* momoIOS */,
-            );
-        };
+		E8D5C3E52984FC23003D1AD0 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1420;
+				LastUpgradeCheck = 1420;
+				TargetAttributes = {
+					E8D5C3EC2984FC23003D1AD0 = {
+						CreatedOnToolsVersion = 14.2;
+					};
+				};
+			};
+			buildConfigurationList = E8D5C3E82984FC23003D1AD0 /* Build configuration list for PBXProject "momoIOS" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = E8D5C3E42984FC23003D1AD0;
+			packageReferences = (
+				E8D5C4052984FD73003D1AD0 /* XCRemoteSwiftPackageReference "SnapKit" */,
+				E83238E72984FDDA00DC83C2 /* XCRemoteSwiftPackageReference "RxSwift" */,
+				E83238EA2984FE0800DC83C2 /* XCRemoteSwiftPackageReference "Toast-Swift" */,
+				E83238ED2984FE3200DC83C2 /* XCRemoteSwiftPackageReference "Alamofire" */,
+			);
+			productRefGroup = E8D5C3EE2984FC23003D1AD0 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				E8D5C3EC2984FC23003D1AD0 /* momoIOS */,
+			);
+		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-        E8D5C3EB2984FC23003D1AD0 /* Resources */ = {
-            isa = PBXResourcesBuildPhase;
-            buildActionMask = 2147483647;
-            files = (
-                E8D5C3FA2984FC25003D1AD0 /* Assets.xcassets in Resources */,
-            );
-            runOnlyForDeploymentPostprocessing = 0;
-        };
+		E8D5C3EB2984FC23003D1AD0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E8D5C3FA2984FC25003D1AD0 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-        E8D5C4042984FCCA003D1AD0 /* SwiftLint Script */ = {
-            isa = PBXShellScriptBuildPhase;
-            buildActionMask = 2147483647;
-            files = (
-            );
-            inputFileListPaths = (
-            );
-            inputPaths = (
-            );
-            name = "SwiftLint Script";
-            outputFileListPaths = (
-            );
-            outputPaths = (
-            );
-            runOnlyForDeploymentPostprocessing = 0;
-            shellPath = /bin/sh;
-            shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-        };
+		E8D5C4042984FCCA003D1AD0 /* SwiftLint Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "SwiftLint Script";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-        E8D5C3E92984FC23003D1AD0 /* Sources */ = {
-            isa = PBXSourcesBuildPhase;
-            buildActionMask = 2147483647;
-            files = (
-                BF04086D2987E38C00F1129B /* RegistrationController.swift in Sources */,
-                E8D5C3F52984FC23003D1AD0 /* ViewController.swift in Sources */,
-                E8D5C3F12984FC23003D1AD0 /* AppDelegate.swift in Sources */,
-                BF04086F2987E70200F1129B /* CheckSecurityCodeController.swift in Sources */,
-                E8D5C3F32984FC23003D1AD0 /* SceneDelegate.swift in Sources */,
-                3A75FC10298827BE00B36A46 /* MainAttendanceCodeCell.swift in Sources */,
-                E83238F1298506A000DC83C2 /* MainViewController.swift in Sources */,
-                BF998900298BB0D3005723C7 /* InputMemberInfoController.swift in Sources */,
-                BF0408632987B3AA00F1129B /* LoginController.swift in Sources */,
-                BF04086B2987E34800F1129B /* AuthCommonConstants.swift in Sources */,
-                3A5AC31029898B330080323A /* UIButton+Extension.swift in Sources */,
-                E8207934298A22D000B36FC9 /* MainSessionInfoCell.swift in Sources */,
-                E8207932298A163400B36FC9 /* UIView+Extension.swift in Sources */,
-                E820792D298A137700B36FC9 /* MainSessionTimeCell.swift in Sources */,
-                E820792B298A119900B36FC9 /* MainSessionDetailCell.swift in Sources */,
-                E8207936298A248200B36FC9 /* MainSessionNoInfoCell.swift in Sources */,
-                3AA713D1298946FF006F922F /* UIColor+Extension.swift in Sources */,
-                3AA713C929884007006F922F /* MainAttendanceDoneCell.swift in Sources */,
-                E820792F298A138500B36FC9 /* MainSessionAbsentCell.swift in Sources */,
-            );
-            runOnlyForDeploymentPostprocessing = 0;
-        };
+		E8D5C3E92984FC23003D1AD0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF04086D2987E38C00F1129B /* RegistrationController.swift in Sources */,
+				E8D5C3F52984FC23003D1AD0 /* ViewController.swift in Sources */,
+				E8D5C3F12984FC23003D1AD0 /* AppDelegate.swift in Sources */,
+				BF04086F2987E70200F1129B /* CheckSecurityCodeController.swift in Sources */,
+				E8D5C3F32984FC23003D1AD0 /* SceneDelegate.swift in Sources */,
+				3A75FC10298827BE00B36A46 /* MainAttendanceCodeCell.swift in Sources */,
+				E83238F1298506A000DC83C2 /* MainViewController.swift in Sources */,
+				BF998900298BB0D3005723C7 /* InputMemberInfoController.swift in Sources */,
+				BF0408632987B3AA00F1129B /* LoginController.swift in Sources */,
+				BF04086B2987E34800F1129B /* AuthCommonConstants.swift in Sources */,
+				3A5AC31029898B330080323A /* UIButton+Extension.swift in Sources */,
+				E8207934298A22D000B36FC9 /* MainSessionInfoCell.swift in Sources */,
+				E8207932298A163400B36FC9 /* UIView+Extension.swift in Sources */,
+				E820792D298A137700B36FC9 /* MainSessionTimeCell.swift in Sources */,
+				E820792B298A119900B36FC9 /* MainSessionDetailCell.swift in Sources */,
+				E8207936298A248200B36FC9 /* MainSessionNoInfoCell.swift in Sources */,
+				3AA713D1298946FF006F922F /* UIColor+Extension.swift in Sources */,
+				3AA713C929884007006F922F /* MainAttendanceDoneCell.swift in Sources */,
+				E820792F298A138500B36FC9 /* MainSessionAbsentCell.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
-        E8D5C3FF2984FC25003D1AD0 /* Debug */ = {
-            isa = XCBuildConfiguration;
-            buildSettings = {
-                ALWAYS_SEARCH_USER_PATHS = NO;
-                CLANG_ANALYZER_NONNULL = YES;
-                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-                CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-                CLANG_ENABLE_MODULES = YES;
-                CLANG_ENABLE_OBJC_ARC = YES;
-                CLANG_ENABLE_OBJC_WEAK = YES;
-                CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-                CLANG_WARN_BOOL_CONVERSION = YES;
-                CLANG_WARN_COMMA = YES;
-                CLANG_WARN_CONSTANT_CONVERSION = YES;
-                CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-                CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-                CLANG_WARN_EMPTY_BODY = YES;
-                CLANG_WARN_ENUM_CONVERSION = YES;
-                CLANG_WARN_INFINITE_RECURSION = YES;
-                CLANG_WARN_INT_CONVERSION = YES;
-                CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-                CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-                CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-                CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-                CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-                CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-                CLANG_WARN_STRICT_PROTOTYPES = YES;
-                CLANG_WARN_SUSPICIOUS_MOVE = YES;
-                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-                CLANG_WARN_UNREACHABLE_CODE = YES;
-                CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-                COPY_PHASE_STRIP = NO;
-                DEBUG_INFORMATION_FORMAT = dwarf;
-                ENABLE_STRICT_OBJC_MSGSEND = YES;
-                ENABLE_TESTABILITY = YES;
-                GCC_C_LANGUAGE_STANDARD = gnu11;
-                GCC_DYNAMIC_NO_PIC = NO;
-                GCC_NO_COMMON_BLOCKS = YES;
-                GCC_OPTIMIZATION_LEVEL = 0;
-                GCC_PREPROCESSOR_DEFINITIONS = (
-                    "DEBUG=1",
-                    "$(inherited)",
-                );
-                GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-                GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-                GCC_WARN_UNDECLARED_SELECTOR = YES;
-                GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-                GCC_WARN_UNUSED_FUNCTION = YES;
-                GCC_WARN_UNUSED_VARIABLE = YES;
-                IPHONEOS_DEPLOYMENT_TARGET = 16.2;
-                MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
-                MTL_FAST_MATH = YES;
-                ONLY_ACTIVE_ARCH = YES;
-                SDKROOT = iphoneos;
-                SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-                SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-            };
-            name = Debug;
-        };
-        E8D5C4002984FC25003D1AD0 /* Release */ = {
-            isa = XCBuildConfiguration;
-            buildSettings = {
-                ALWAYS_SEARCH_USER_PATHS = NO;
-                CLANG_ANALYZER_NONNULL = YES;
-                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-                CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-                CLANG_ENABLE_MODULES = YES;
-                CLANG_ENABLE_OBJC_ARC = YES;
-                CLANG_ENABLE_OBJC_WEAK = YES;
-                CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-                CLANG_WARN_BOOL_CONVERSION = YES;
-                CLANG_WARN_COMMA = YES;
-                CLANG_WARN_CONSTANT_CONVERSION = YES;
-                CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-                CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-                CLANG_WARN_EMPTY_BODY = YES;
-                CLANG_WARN_ENUM_CONVERSION = YES;
-                CLANG_WARN_INFINITE_RECURSION = YES;
-                CLANG_WARN_INT_CONVERSION = YES;
-                CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-                CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-                CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-                CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-                CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-                CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-                CLANG_WARN_STRICT_PROTOTYPES = YES;
-                CLANG_WARN_SUSPICIOUS_MOVE = YES;
-                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-                CLANG_WARN_UNREACHABLE_CODE = YES;
-                CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-                COPY_PHASE_STRIP = NO;
-                DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-                ENABLE_NS_ASSERTIONS = NO;
-                ENABLE_STRICT_OBJC_MSGSEND = YES;
-                GCC_C_LANGUAGE_STANDARD = gnu11;
-                GCC_NO_COMMON_BLOCKS = YES;
-                GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-                GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-                GCC_WARN_UNDECLARED_SELECTOR = YES;
-                GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-                GCC_WARN_UNUSED_FUNCTION = YES;
-                GCC_WARN_UNUSED_VARIABLE = YES;
-                IPHONEOS_DEPLOYMENT_TARGET = 16.2;
-                MTL_ENABLE_DEBUG_INFO = NO;
-                MTL_FAST_MATH = YES;
-                SDKROOT = iphoneos;
-                SWIFT_COMPILATION_MODE = wholemodule;
-                SWIFT_OPTIMIZATION_LEVEL = "-O";
-                VALIDATE_PRODUCT = YES;
-            };
-            name = Release;
-        };
-        E8D5C4022984FC25003D1AD0 /* Debug */ = {
-            isa = XCBuildConfiguration;
-            buildSettings = {
-                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-                ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-                CODE_SIGN_STYLE = Automatic;
-                CURRENT_PROJECT_VERSION = 1;
-                GENERATE_INFOPLIST_FILE = YES;
-                INFOPLIST_FILE = momoIOS/Info.plist;
-                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-                INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-                IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-                LD_RUNPATH_SEARCH_PATHS = (
-                    "$(inherited)",
-                    "@executable_path/Frameworks",
-                );
-                MARKETING_VERSION = 1.0;
-                PRODUCT_BUNDLE_IDENTIFIER = com.teamnexters.momoIOS;
-                PRODUCT_NAME = "$(TARGET_NAME)";
-                SWIFT_EMIT_LOC_STRINGS = YES;
-                SWIFT_VERSION = 5.0;
-                TARGETED_DEVICE_FAMILY = "1,2";
-            };
-            name = Debug;
-        };
-        E8D5C4032984FC25003D1AD0 /* Release */ = {
-            isa = XCBuildConfiguration;
-            buildSettings = {
-                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-                ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-                CODE_SIGN_STYLE = Automatic;
-                CURRENT_PROJECT_VERSION = 1;
-                GENERATE_INFOPLIST_FILE = YES;
-                INFOPLIST_FILE = momoIOS/Info.plist;
-                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-                INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-                IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-                LD_RUNPATH_SEARCH_PATHS = (
-                    "$(inherited)",
-                    "@executable_path/Frameworks",
-                );
-                MARKETING_VERSION = 1.0;
-                PRODUCT_BUNDLE_IDENTIFIER = com.teamnexters.momoIOS;
-                PRODUCT_NAME = "$(TARGET_NAME)";
-                SWIFT_EMIT_LOC_STRINGS = YES;
-                SWIFT_VERSION = 5.0;
-                TARGETED_DEVICE_FAMILY = "1,2";
-            };
-            name = Release;
-        };
+		E8D5C3FF2984FC25003D1AD0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		E8D5C4002984FC25003D1AD0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		E8D5C4022984FC25003D1AD0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = momoIOS/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.teamnexters.momoIOS;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		E8D5C4032984FC25003D1AD0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = momoIOS/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.teamnexters.momoIOS;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-        E8D5C3E82984FC23003D1AD0 /* Build configuration list for PBXProject "momoIOS" */ = {
-            isa = XCConfigurationList;
-            buildConfigurations = (
-                E8D5C3FF2984FC25003D1AD0 /* Debug */,
-                E8D5C4002984FC25003D1AD0 /* Release */,
-            );
-            defaultConfigurationIsVisible = 0;
-            defaultConfigurationName = Release;
-        };
-        E8D5C4012984FC25003D1AD0 /* Build configuration list for PBXNativeTarget "momoIOS" */ = {
-            isa = XCConfigurationList;
-            buildConfigurations = (
-                E8D5C4022984FC25003D1AD0 /* Debug */,
-                E8D5C4032984FC25003D1AD0 /* Release */,
-            );
-            defaultConfigurationIsVisible = 0;
-            defaultConfigurationName = Release;
-        };
+		E8D5C3E82984FC23003D1AD0 /* Build configuration list for PBXProject "momoIOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E8D5C3FF2984FC25003D1AD0 /* Debug */,
+				E8D5C4002984FC25003D1AD0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E8D5C4012984FC25003D1AD0 /* Build configuration list for PBXNativeTarget "momoIOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E8D5C4022984FC25003D1AD0 /* Debug */,
+				E8D5C4032984FC25003D1AD0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-        E83238E72984FDDA00DC83C2 /* XCRemoteSwiftPackageReference "RxSwift" */ = {
-            isa = XCRemoteSwiftPackageReference;
-            repositoryURL = "https://github.com/ReactiveX/RxSwift";
-            requirement = {
-                kind = upToNextMajorVersion;
-                minimumVersion = 6.0.0;
-            };
-        };
-        E83238EA2984FE0800DC83C2 /* XCRemoteSwiftPackageReference "Toast-Swift" */ = {
-            isa = XCRemoteSwiftPackageReference;
-            repositoryURL = "https://github.com/scalessec/Toast-Swift";
-            requirement = {
-                kind = upToNextMajorVersion;
-                minimumVersion = 5.0.0;
-            };
-        };
-        E83238ED2984FE3200DC83C2 /* XCRemoteSwiftPackageReference "Alamofire" */ = {
-            isa = XCRemoteSwiftPackageReference;
-            repositoryURL = "https://github.com/Alamofire/Alamofire";
-            requirement = {
-                kind = upToNextMajorVersion;
-                minimumVersion = 5.0.0;
-            };
-        };
-        E8D5C4052984FD73003D1AD0 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
-            isa = XCRemoteSwiftPackageReference;
-            repositoryURL = "https://github.com/SnapKit/SnapKit";
-            requirement = {
-                kind = upToNextMajorVersion;
-                minimumVersion = 5.0.0;
-            };
-        };
+		E83238E72984FDDA00DC83C2 /* XCRemoteSwiftPackageReference "RxSwift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ReactiveX/RxSwift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 6.0.0;
+			};
+		};
+		E83238EA2984FE0800DC83C2 /* XCRemoteSwiftPackageReference "Toast-Swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/scalessec/Toast-Swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
+			};
+		};
+		E83238ED2984FE3200DC83C2 /* XCRemoteSwiftPackageReference "Alamofire" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Alamofire/Alamofire";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
+			};
+		};
+		E8D5C4052984FD73003D1AD0 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SnapKit/SnapKit";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-        E83238E82984FDDA00DC83C2 /* RxSwift */ = {
-            isa = XCSwiftPackageProductDependency;
-            package = E83238E72984FDDA00DC83C2 /* XCRemoteSwiftPackageReference "RxSwift" */;
-            productName = RxSwift;
-        };
-        E83238EB2984FE0800DC83C2 /* Toast */ = {
-            isa = XCSwiftPackageProductDependency;
-            package = E83238EA2984FE0800DC83C2 /* XCRemoteSwiftPackageReference "Toast-Swift" */;
-            productName = Toast;
-        };
-        E83238EE2984FE3200DC83C2 /* Alamofire */ = {
-            isa = XCSwiftPackageProductDependency;
-            package = E83238ED2984FE3200DC83C2 /* XCRemoteSwiftPackageReference "Alamofire" */;
-            productName = Alamofire;
-        };
-        E8D5C4062984FD73003D1AD0 /* SnapKit */ = {
-            isa = XCSwiftPackageProductDependency;
-            package = E8D5C4052984FD73003D1AD0 /* XCRemoteSwiftPackageReference "SnapKit" */;
-            productName = SnapKit;
-        };
+		E83238E82984FDDA00DC83C2 /* RxSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E83238E72984FDDA00DC83C2 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxSwift;
+		};
+		E83238EB2984FE0800DC83C2 /* Toast */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E83238EA2984FE0800DC83C2 /* XCRemoteSwiftPackageReference "Toast-Swift" */;
+			productName = Toast;
+		};
+		E83238EE2984FE3200DC83C2 /* Alamofire */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E83238ED2984FE3200DC83C2 /* XCRemoteSwiftPackageReference "Alamofire" */;
+			productName = Alamofire;
+		};
+		E8D5C4062984FD73003D1AD0 /* SnapKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E8D5C4052984FD73003D1AD0 /* XCRemoteSwiftPackageReference "SnapKit" */;
+			productName = SnapKit;
+		};
 /* End XCSwiftPackageProductDependency section */
-    };
-    rootObject = E8D5C3E52984FC23003D1AD0 /* Project object */;
+	};
+	rootObject = E8D5C3E52984FC23003D1AD0 /* Project object */;
 }

--- a/momoIOS.xcodeproj/project.pbxproj
+++ b/momoIOS.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		BF0408632987B3AA00F1129B /* LoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0408622987B3AA00F1129B /* LoginController.swift */; };
 		BF04086B2987E34800F1129B /* AuthCommonConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086A2987E34800F1129B /* AuthCommonConstants.swift */; };
 		BF04086D2987E38C00F1129B /* RegistrationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086C2987E38C00F1129B /* RegistrationController.swift */; };
+		BF04086F2987E70200F1129B /* CheckSecurityCodeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086E2987E70200F1129B /* CheckSecurityCodeController.swift */; };
 		E83238E92984FDDA00DC83C2 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E83238E82984FDDA00DC83C2 /* RxSwift */; };
 		E83238EC2984FE0800DC83C2 /* Toast in Frameworks */ = {isa = PBXBuildFile; productRef = E83238EB2984FE0800DC83C2 /* Toast */; };
 		E83238EF2984FE3200DC83C2 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = E83238EE2984FE3200DC83C2 /* Alamofire */; };
@@ -45,6 +46,7 @@
 		BF0408622987B3AA00F1129B /* LoginController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginController.swift; sourceTree = "<group>"; };
 		BF04086A2987E34800F1129B /* AuthCommonConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCommonConstants.swift; sourceTree = "<group>"; };
 		BF04086C2987E38C00F1129B /* RegistrationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationController.swift; sourceTree = "<group>"; };
+		BF04086E2987E70200F1129B /* CheckSecurityCodeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckSecurityCodeController.swift; sourceTree = "<group>"; };
 		E83238F0298506A000DC83C2 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		E8D5C3ED2984FC23003D1AD0 /* momoIOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = momoIOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E8D5C3F02984FC23003D1AD0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -101,6 +103,7 @@
 				BF0408622987B3AA00F1129B /* LoginController.swift */,
 				BF04086C2987E38C00F1129B /* RegistrationController.swift */,
 				BF04086A2987E34800F1129B /* AuthCommonConstants.swift */,
+				BF04086E2987E70200F1129B /* CheckSecurityCodeController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -247,6 +250,7 @@
 				BF04086D2987E38C00F1129B /* RegistrationController.swift in Sources */,
 				E8D5C3F52984FC23003D1AD0 /* ViewController.swift in Sources */,
 				E8D5C3F12984FC23003D1AD0 /* AppDelegate.swift in Sources */,
+				BF04086F2987E70200F1129B /* CheckSecurityCodeController.swift in Sources */,
 				E8D5C3F32984FC23003D1AD0 /* SceneDelegate.swift in Sources */,
 				3A75FC10298827BE00B36A46 /* MainAttendanceCodeCell.swift in Sources */,
 				E83238F1298506A000DC83C2 /* MainViewController.swift in Sources */,

--- a/momoIOS/Authentication/Controller/AuthCommonConstants.swift
+++ b/momoIOS/Authentication/Controller/AuthCommonConstants.swift
@@ -1,0 +1,67 @@
+//
+//  Constants.swift
+//  momoIOS
+//
+//  Created by 문다 on 2023/01/30.
+//
+
+import UIKit
+
+// MARK: - Colors
+let authDefaultButtonColor = UIColor(red: 56/255, green: 56/255, blue: 56/255, alpha: 1)
+
+// MARK: - UILabel
+let welcomeTitle: UILabel = {
+    let title = UILabel()
+    title.text = "간단한 출석체크,\n모두모여에서"
+    title.font = UIFont.systemFont(ofSize: 40, weight: .regular)
+    title.numberOfLines = 0
+    return title
+}()
+
+// MARK: - UITextField
+func inputContainerView(placeholder: String) -> UITextField {
+    let textfield = UITextField()
+    textfield.heightAnchor.constraint(equalToConstant: 55).isActive = true
+    textfield.placeholder = placeholder
+    textfield.borderStyle = .roundedRect
+    textfield.font = UIFont.systemFont(ofSize: 16)
+    textfield.attributedPlaceholder = NSAttributedString(string: placeholder, attributes: [NSAttributedString.Key.foregroundColor: UIColor.gray])
+    return textfield
+}
+
+// MARK: - Buttons
+func actionButton(title: String) -> UIButton {
+    let button = UIButton(type: .system)
+    button.setTitle(title, for: .normal)
+    button.setTitleColor(UIColor.white, for: .normal)
+    button.backgroundColor = authDefaultButtonColor
+    button.heightAnchor.constraint(equalToConstant: 55).isActive = true
+    button.layer.cornerRadius = 8
+    button.titleLabel?.font = .boldSystemFont(ofSize: 18)
+    return button
+}
+
+func pushAnotherViewButton(subtitle: String, title: String) -> UIButton {
+    let button = UIButton(type: .system)
+    let attributedTitle = NSMutableAttributedString(
+        string: subtitle,
+        attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16),
+                     NSAttributedString.Key.foregroundColor: UIColor.gray])
+    attributedTitle.append(NSAttributedString(
+        string: "  \(title)",
+        attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16),
+                     NSAttributedString.Key.foregroundColor: UIColor.black]))
+    button.setAttributedTitle(attributedTitle, for: .normal)
+    return button
+}
+
+let pushHelpLogin: UIButton = {
+    let button = UIButton(type: .system)
+    let attributedTitle = NSMutableAttributedString(
+        string: "로그인에 문제가 있나요?",
+        attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16),
+                     NSAttributedString.Key.foregroundColor: UIColor.gray])
+    button.setAttributedTitle(attributedTitle, for: .normal)
+    return button
+}()

--- a/momoIOS/Authentication/Controller/AuthCommonConstants.swift
+++ b/momoIOS/Authentication/Controller/AuthCommonConstants.swift
@@ -65,3 +65,11 @@ let pushHelpLogin: UIButton = {
     button.setAttributedTitle(attributedTitle, for: .normal)
     return button
 }()
+
+// MARK: - Methods
+func setupUIStackView(_ views: [UIView]) -> UIStackView {
+    let container = UIStackView(arrangedSubviews: views)
+    container.axis = .vertical
+    container.spacing = 5
+    return container
+}

--- a/momoIOS/Authentication/Controller/AuthCommonConstants.swift
+++ b/momoIOS/Authentication/Controller/AuthCommonConstants.swift
@@ -26,6 +26,7 @@ func inputContainerView(placeholder: String, isSecureField: Bool = false) -> UIT
     textfield.placeholder = placeholder
     textfield.borderStyle = .roundedRect
     textfield.font = UIFont.systemFont(ofSize: 16)
+    textfield.textColor = .black
     textfield.attributedPlaceholder = NSAttributedString(string: placeholder, attributes: [NSAttributedString.Key.foregroundColor: UIColor.gray])
     textfield.isSecureTextEntry = isSecureField
     return textfield

--- a/momoIOS/Authentication/Controller/AuthCommonConstants.swift
+++ b/momoIOS/Authentication/Controller/AuthCommonConstants.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 // MARK: - Colors
-let authDefaultButtonColor = UIColor(red: 56/255, green: 56/255, blue: 56/255, alpha: 1)
+let authDefaultButtonColor: UIColor = .rgba(56, 56, 56, 1)
 
 // MARK: - UILabel
 let welcomeTitle: UILabel = {

--- a/momoIOS/Authentication/Controller/AuthCommonConstants.swift
+++ b/momoIOS/Authentication/Controller/AuthCommonConstants.swift
@@ -20,13 +20,14 @@ let welcomeTitle: UILabel = {
 }()
 
 // MARK: - UITextField
-func inputContainerView(placeholder: String) -> UITextField {
+func inputContainerView(placeholder: String, isSecureField: Bool = false) -> UITextField {
     let textfield = UITextField()
     textfield.heightAnchor.constraint(equalToConstant: 55).isActive = true
     textfield.placeholder = placeholder
     textfield.borderStyle = .roundedRect
     textfield.font = UIFont.systemFont(ofSize: 16)
     textfield.attributedPlaceholder = NSAttributedString(string: placeholder, attributes: [NSAttributedString.Key.foregroundColor: UIColor.gray])
+    textfield.isSecureTextEntry = isSecureField
     return textfield
 }
 

--- a/momoIOS/Authentication/Controller/CheckSecurityCodeController.swift
+++ b/momoIOS/Authentication/Controller/CheckSecurityCodeController.swift
@@ -50,7 +50,7 @@ class CheckSecurityCodeController: UIViewController {
     @objc func handleCompleteRegistration() {
         self.view.window?.rootViewController?.dismiss(animated: true, completion: {
             // TODO: 확인필요, 보안코드가 일치한 후 어디까지 pop하고 정보입력뷰를 present하는지
-            let nav = InputMemberInfoController()
+            let nav = UINavigationController(rootViewController: InputMemberInfoController())
             nav.modalPresentationStyle = .fullScreen
             self.present(nav, animated: true, completion: nil)
         })    }

--- a/momoIOS/Authentication/Controller/CheckSecurityCodeController.swift
+++ b/momoIOS/Authentication/Controller/CheckSecurityCodeController.swift
@@ -37,6 +37,9 @@ class CheckSecurityCodeController: UIViewController {
     // MARK: - Lifecyle
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        codeField.delegate = self
+        
         view.backgroundColor = .white
         configureUI()
         codeField.becomeFirstResponder()
@@ -78,5 +81,18 @@ class CheckSecurityCodeController: UIViewController {
             make.left.right.equalToSuperview().inset(20)
         }
         completeButton.addTarget(self, action: #selector(handleCompleteRegistration), for: .touchUpInside)
+    }
+}
+
+extension CheckSecurityCodeController: UITextFieldDelegate {
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard let text = textField.text else { return false }
+        let maxLength: Int = 12
+            
+        // 최대 글자수 이상을 입력한 이후에는 중간에 다른 글자를 추가할 수 없게끔 작동
+        if text.count >= maxLength && range.length == 0 && range.location <= maxLength {
+            return false
+        }
+        return true
     }
 }

--- a/momoIOS/Authentication/Controller/CheckSecurityCodeController.swift
+++ b/momoIOS/Authentication/Controller/CheckSecurityCodeController.swift
@@ -29,7 +29,7 @@ class CheckSecurityCodeController: UIViewController {
         border.backgroundColor = .black
         return border
     }()
-    
+
     private let completeButton: UIButton = {
         return actionButton(title: "가입완료!")
     }()
@@ -39,6 +39,7 @@ class CheckSecurityCodeController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .white
         configureUI()
+        codeField.becomeFirstResponder()
     }
     
     // MARK: - Helpers
@@ -51,7 +52,7 @@ class CheckSecurityCodeController: UIViewController {
         
         view.addSubview(codeField)
         codeField.snp.makeConstraints { make in
-            make.top.equalTo(guidePhrase.snp.bottom).offset(130)
+            make.top.equalTo(guidePhrase.snp.bottom).offset(100)
             make.left.right.equalToSuperview().inset(20)
         }
         

--- a/momoIOS/Authentication/Controller/CheckSecurityCodeController.swift
+++ b/momoIOS/Authentication/Controller/CheckSecurityCodeController.swift
@@ -41,6 +41,7 @@ class CheckSecurityCodeController: UIViewController {
         codeField.delegate = self
         
         view.backgroundColor = .white
+        setNavCustom()
         configureUI()
         codeField.becomeFirstResponder()
     }
@@ -55,7 +56,20 @@ class CheckSecurityCodeController: UIViewController {
         })    }
     
     // MARK: - Helpers
-    func configureUI() {
+    
+    private func setNavCustom() {
+        let navBar = self.navigationController?.navigationBar
+        navBar?.tintColor = .black
+        navBar?.backIndicatorImage = UIImage(systemName: "arrow.left")
+        navBar?.backIndicatorTransitionMaskImage = UIImage(systemName: "arrow.left")
+        navBar?.topItem?.title = ""
+        
+        let title = UILabel()
+        title.text = "회원가입"
+        self.navigationItem.titleView = title
+    }
+    
+    private func configureUI() {
         view.addSubview(guidePhrase)
         guidePhrase.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide).offset(50)
@@ -89,7 +103,6 @@ extension CheckSecurityCodeController: UITextFieldDelegate {
         guard let text = textField.text else { return false }
         let maxLength: Int = 12
             
-        // 최대 글자수 이상을 입력한 이후에는 중간에 다른 글자를 추가할 수 없게끔 작동
         if text.count >= maxLength && range.length == 0 && range.location <= maxLength {
             return false
         }

--- a/momoIOS/Authentication/Controller/CheckSecurityCodeController.swift
+++ b/momoIOS/Authentication/Controller/CheckSecurityCodeController.swift
@@ -1,0 +1,71 @@
+//
+//  CheckSecurityCodeController.swift
+//  momoIOS
+//
+//  Created by 문다 on 2023/01/30.
+//
+
+import UIKit
+
+class CheckSecurityCodeController: UIViewController {
+    // MARK: - Properties
+    private let guidePhrase: UILabel = {
+        let phrase = UILabel()
+        phrase.text = "보안코드를\n입력해주세요."
+        phrase.font = UIFont.systemFont(ofSize: 40, weight: .regular)
+        phrase.numberOfLines = 0
+        return phrase
+    }()
+    
+    private let codeField: UITextField = {
+        let field = UITextField()
+        field.font = UIFont.systemFont(ofSize: 40)
+        field.textAlignment = .center
+        return field
+    }()
+    
+    private let borderView: UIView = {
+        let border = UIView()
+        border.backgroundColor = .black
+        return border
+    }()
+    
+    private let completeButton: UIButton = {
+        return actionButton(title: "가입완료!")
+    }()
+    
+    // MARK: - Lifecyle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        configureUI()
+    }
+    
+    // MARK: - Helpers
+    func configureUI() {
+        view.addSubview(guidePhrase)
+        guidePhrase.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(50)
+            make.left.equalToSuperview().offset(20)
+        }
+        
+        view.addSubview(codeField)
+        codeField.snp.makeConstraints { make in
+            make.top.equalTo(guidePhrase.snp.bottom).offset(130)
+            make.left.right.equalToSuperview().inset(20)
+        }
+        
+        view.addSubview(borderView)
+        borderView.snp.makeConstraints { make in
+            make.top.equalTo(codeField.snp.bottom).offset(8)
+            make.left.right.equalToSuperview().inset(20)
+            make.height.equalTo(0.75)
+        }
+        
+        view.addSubview(completeButton)
+        completeButton.snp.makeConstraints { make in
+            make.top.equalTo(borderView.snp.bottom).offset(40)
+            make.left.right.equalToSuperview().inset(20)
+        }
+    }
+}

--- a/momoIOS/Authentication/Controller/CheckSecurityCodeController.swift
+++ b/momoIOS/Authentication/Controller/CheckSecurityCodeController.swift
@@ -70,26 +70,24 @@ class CheckSecurityCodeController: UIViewController {
     }
     
     private func configureUI() {
-        view.addSubview(guidePhrase)
+        view.addSubviews(guidePhrase, codeField, borderView, completeButton)
+
         guidePhrase.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide).offset(50)
             make.left.equalToSuperview().offset(20)
         }
         
-        view.addSubview(codeField)
         codeField.snp.makeConstraints { make in
             make.top.equalTo(guidePhrase.snp.bottom).offset(100)
             make.left.right.equalToSuperview().inset(20)
         }
         
-        view.addSubview(borderView)
         borderView.snp.makeConstraints { make in
             make.top.equalTo(codeField.snp.bottom).offset(8)
             make.left.right.equalToSuperview().inset(20)
             make.height.equalTo(0.75)
         }
-        
-        view.addSubview(completeButton)
+
         completeButton.snp.makeConstraints { make in
             make.top.equalTo(borderView.snp.bottom).offset(40)
             make.left.right.equalToSuperview().inset(20)

--- a/momoIOS/Authentication/Controller/CheckSecurityCodeController.swift
+++ b/momoIOS/Authentication/Controller/CheckSecurityCodeController.swift
@@ -42,6 +42,15 @@ class CheckSecurityCodeController: UIViewController {
         codeField.becomeFirstResponder()
     }
     
+    // MARK: Selectors
+    @objc func handleCompleteRegistration() {
+        self.view.window?.rootViewController?.dismiss(animated: true, completion: {
+            // TODO: 확인필요, 보안코드가 일치한 후 어디까지 pop하고 정보입력뷰를 present하는지
+            let nav = InputMemberInfoController()
+            nav.modalPresentationStyle = .fullScreen
+            self.present(nav, animated: true, completion: nil)
+        })    }
+    
     // MARK: - Helpers
     func configureUI() {
         view.addSubview(guidePhrase)
@@ -68,5 +77,6 @@ class CheckSecurityCodeController: UIViewController {
             make.top.equalTo(borderView.snp.bottom).offset(40)
             make.left.right.equalToSuperview().inset(20)
         }
+        completeButton.addTarget(self, action: #selector(handleCompleteRegistration), for: .touchUpInside)
     }
 }

--- a/momoIOS/Authentication/Controller/InputMemberInfoController.swift
+++ b/momoIOS/Authentication/Controller/InputMemberInfoController.swift
@@ -6,7 +6,171 @@
 //
 
 import UIKit
+import SnapKit
 
 class InputMemberInfoController: UIViewController {
+    // MARK: - set Properties
     
+    private func setLabel(text: String) -> UILabel {
+        let label = UILabel()
+        label.text = text
+        label.font = .systemFont(ofSize: 16)
+        label.textColor = .black
+        return label
+    }
+    
+    private func setInputNameView() -> UIView {
+        let view = UIView()
+        
+        let label = setLabel(text: "이름")
+        let textField = inputContainerView(placeholder: "")
+        
+        view.addSubviews(label, textField)
+        label.snp.makeConstraints { make in
+            make.top.equalTo(view.snp.top)
+            make.left.right.equalToSuperview()
+        }
+        textField.snp.makeConstraints { make in
+            make.top.equalTo(label.snp.bottom).offset(15)
+            make.width.equalTo(view)
+        }
+        return view
+    }
+    
+    private func setInputYearView() -> UIView {
+        let view = UIView()
+        
+        let titleLabel = setLabel(text: "기수")
+        let textField = inputContainerView(placeholder: "")
+        let yearLabel = setLabel(text: "기")
+        
+        view.addSubviews(titleLabel, textField, yearLabel)
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalTo(view.snp.top)
+            make.left.equalTo(view.snp.left)
+        }
+        textField.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(15)
+            make.left.equalTo(view.snp.left)
+            make.width.equalTo(200)
+        }
+        yearLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(textField)
+            make.left.equalTo(textField.snp.right).offset(15)
+        }
+        return view
+    }
+    
+    private lazy var designerButton = setJobButton(jobName: "Designer", width: 200, tag: 1)
+    private lazy var developerButton = setJobButton(jobName: "Developer", width: 215, tag: 2)
+    
+    private func setInputJobView() -> UIView {
+        let view = UIView()
+        
+        let label = setLabel(text: "직군")
+//        let designerButton = setJobButton(jobName: "Designer", width: 200, tag: 1)
+//        let developerButton = setJobButton(jobName: "Developer", width: 215, tag: 2)
+        
+        view.addSubviews(label, designerButton, developerButton)
+        label.snp.makeConstraints { make in
+            make.top.equalTo(view.snp.top)
+            make.left.equalTo(view.snp.left)
+        }
+        designerButton.snp.makeConstraints { make in
+            make.top.equalTo(label.snp.bottom).offset(15)
+            make.left.equalTo(view.snp.left)
+        }
+        developerButton.snp.makeConstraints { make in
+            make.centerY.equalTo(designerButton)
+            make.left.equalTo(designerButton.snp.right).offset(15)
+        }
+        designerButton.addTarget(self, action: #selector(handleJobSelection), for: .touchUpInside)
+        developerButton.addTarget(self, action: #selector(handleJobSelection), for: .touchUpInside)
+        return view
+    }
+    
+    private func setJobButton(jobName: String, width: CGFloat, tag: Int) -> UIButton {
+        let button = UIButton()
+        
+        button.setTitle(jobName, for: .normal)
+        button.setTitleColor(.gray, for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 15)
+        button.contentEdgeInsets = UIEdgeInsets(top: 13, left: 13, bottom: 13, right: 13)
+        
+        button.frame = CGRect(x: 0, y: 0, width: width, height: 30)
+        button.backgroundColor = .white
+        button.layer.masksToBounds = true
+        button.layer.cornerRadius = 22
+        button.layer.borderWidth = 0.75
+        button.layer.borderColor = UIColor.gray.cgColor
+        
+        button.tag = tag
+        return button
+    }
+    
+    private let completeButton: UIButton = {
+        return actionButton(title: "가입완료!")
+    }()
+    
+    // MARK: - Lifecycles
+    
+    override func viewWillAppear(_ animated: Bool) {
+        self.navigationController?.setNavigationBarHidden(false, animated: animated)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = .white
+        setupCustomNav()
+        configureUI()
+    }
+    
+    // MARK: - Selectors
+    
+    @objc private func handleJobSelection(_ selectedButton: UIButton) {
+        if selectedButton.tag == 1 { // designer
+            designerButton.setTitleColor(.black, for: .normal)
+            designerButton.layer.borderColor = UIColor.black.cgColor
+            developerButton.setTitleColor(.gray, for: .normal)
+            developerButton.layer.borderColor = UIColor.gray.cgColor
+        } else { // developer
+            designerButton.setTitleColor(.gray, for: .normal)
+            designerButton.layer.borderColor = UIColor.gray.cgColor
+            developerButton.setTitleColor(.black, for: .normal)
+            developerButton.layer.borderColor = UIColor.black.cgColor
+        }
+    }
+    
+    // MARK: - Helpers
+    
+    private func setupCustomNav() {
+        let title = UILabel()
+        title.text = "회원정보입력"
+        self.navigationItem.titleView = title
+        self.navigationItem.titleView?.tintColor = .black
+    }
+    
+    private func configureUI() {
+        let inputViews = [setInputNameView(), setInputYearView(), setInputJobView()]
+        inputViews.forEach { view in
+            view.snp.makeConstraints { make in
+                make.height.greaterThanOrEqualTo(100)
+            }
+        }
+        
+        let fieldStack = UIStackView(arrangedSubviews: inputViews)
+        fieldStack.axis = .vertical
+        fieldStack.spacing = 20
+        
+        view.addSubviews(fieldStack, completeButton)
+        fieldStack.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(40)
+            make.horizontalEdges.equalToSuperview().inset(20)
+        }
+        completeButton.snp.makeConstraints { make in
+            make.bottom.equalTo(view.snp.bottom).offset(-50)
+            make.horizontalEdges.equalToSuperview().inset(20)
+        }
+    }
 }

--- a/momoIOS/Authentication/Controller/InputMemberInfoController.swift
+++ b/momoIOS/Authentication/Controller/InputMemberInfoController.swift
@@ -1,0 +1,12 @@
+//
+//  InputMemberInfoController.swift
+//  momoIOS
+//
+//  Created by 문다 on 2023/02/02.
+//
+
+import UIKit
+
+class InputMemberInfoController: UIViewController {
+    
+}

--- a/momoIOS/Authentication/Controller/InputMemberInfoController.swift
+++ b/momoIOS/Authentication/Controller/InputMemberInfoController.swift
@@ -68,8 +68,6 @@ class InputMemberInfoController: UIViewController {
         let view = UIView()
         
         let label = setLabel(text: "직군")
-//        let designerButton = setJobButton(jobName: "Designer", width: 200, tag: 1)
-//        let developerButton = setJobButton(jobName: "Developer", width: 215, tag: 2)
         
         view.addSubviews(label, designerButton, developerButton)
         label.snp.makeConstraints { make in
@@ -123,7 +121,7 @@ class InputMemberInfoController: UIViewController {
         
         view.backgroundColor = .white
         setupCustomNav()
-        configureUI()
+        setupLayout()
     }
     
     // MARK: - Selectors
@@ -151,7 +149,7 @@ class InputMemberInfoController: UIViewController {
         self.navigationItem.titleView?.tintColor = .black
     }
     
-    private func configureUI() {
+    private func setupLayout() {
         let inputViews = [setInputNameView(), setInputYearView(), setInputJobView()]
         inputViews.forEach { view in
             view.snp.makeConstraints { make in

--- a/momoIOS/Authentication/Controller/LoginController.swift
+++ b/momoIOS/Authentication/Controller/LoginController.swift
@@ -45,6 +45,10 @@ class LoginController: UIViewController {
         pushHelpLogin.addTarget(self, action: #selector(handlePushHelpLogin), for: .touchUpInside)
     }
     
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+            self.view.endEditing(true)
+    }
+    
     // MARK: - Selectors
     
     @objc func handlePushRegistrationView() {

--- a/momoIOS/Authentication/Controller/LoginController.swift
+++ b/momoIOS/Authentication/Controller/LoginController.swift
@@ -56,6 +56,13 @@ class LoginController: UIViewController {
     }
     
     @objc func handlePushHelpLogin() {
+        // TODO: 로그인 가이드 url 변경 필요
+        guard let url = URL(string: "https://www.google.co.kr/") else { return }
+        if #available(iOS 10.0, *) {
+            UIApplication.shared.open(url, options: [:])
+        } else {
+            UIApplication.shared.openURL(url)
+        }
     }
     
     // MARK: - Helpers

--- a/momoIOS/Authentication/Controller/LoginController.swift
+++ b/momoIOS/Authentication/Controller/LoginController.swift
@@ -24,7 +24,7 @@ class LoginController: UIViewController {
     }()
     
     private lazy var passwordTextField: UITextField = {
-        return inputContainerView(placeholder: "비밀번호를 입력해주세요")
+        return inputContainerView(placeholder: "비밀번호를 입력해주세요", isSecureField: true)
     }()
     
     private let loginButton: UIButton = {

--- a/momoIOS/Authentication/Controller/LoginController.swift
+++ b/momoIOS/Authentication/Controller/LoginController.swift
@@ -66,8 +66,10 @@ class LoginController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        view.backgroundColor = .white
         configureUI()
+        pushRegistrationViewButton.addTarget(self, action: #selector(handlePushRegistrationView), for: .touchUpInside)
+        pushHelpLogin.addTarget(self, action: #selector(handlePushHelpLogin), for: .touchUpInside)
     }
     
     // MARK: - Selectors
@@ -81,44 +83,29 @@ class LoginController: UIViewController {
     // MARK: - Helpers
     
     func configureUI() {
-        view.backgroundColor = .white
         view.addSubview(welcomeTitle)
-        
         welcomeTitle.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide).offset(50)
             make.left.equalTo(view).offset(20)
         }
         
-        let stack = UIStackView(arrangedSubviews: [emailTextField, passwordTextField, loginButton])
-        stack.axis = .vertical
-        stack.spacing = 15
-        view.addSubview(stack)
-        stack.snp.makeConstraints { make in
+        let fieldStack = UIStackView(arrangedSubviews: [emailTextField, passwordTextField, loginButton])
+        fieldStack.axis = .vertical
+        fieldStack.spacing = 15
+        view.addSubview(fieldStack)
+        fieldStack.snp.makeConstraints { make in
             make.top.equalTo(welcomeTitle.snp.bottom).offset(50)
-            make.left.equalTo(view).offset(20)
-            make.right.equalTo(view).offset(-20)
+            make.left.right.equalToSuperview().inset(20)
         }
         
-        view.addSubview(loginButton)
-        loginButton.snp.makeConstraints { make in
-            make.top.equalTo(stack.snp.bottom).offset(20)
-            make.left.equalTo(view).offset(20)
-            make.right.equalTo(view).offset(-20)
+        let helpStack = UIStackView(arrangedSubviews: [pushRegistrationViewButton, pushHelpLogin])
+        helpStack.axis = .vertical
+        helpStack.spacing = 30
+        view.addSubview(helpStack)
+        helpStack.snp.makeConstraints { make in
+            make.top.equalTo(fieldStack.snp.bottom).offset(20)
+            make.left.right.equalToSuperview().inset(20)
         }
-        
-        view.addSubview(pushRegistrationViewButton)
-        pushRegistrationViewButton.snp.makeConstraints { make in
-            make.top.equalTo(loginButton.snp.bottom).offset(20)
-            make.left.right.equalToSuperview()
-        }
-        pushRegistrationViewButton.addTarget(self, action: #selector(handlePushRegistrationView), for: .touchUpInside)
-
-        view.addSubview(pushHelpLogin)
-        pushHelpLogin.snp.makeConstraints { make in
-            make.top.equalTo(pushRegistrationViewButton.snp.bottom).offset(30)
-            make.left.right.equalToSuperview()
-        }
-        pushHelpLogin.addTarget(self, action: #selector(handlePushHelpLogin), for: .touchUpInside)
     }
 }
 
@@ -126,12 +113,12 @@ class LoginController: UIViewController {
 
 extension LoginController {
     func inputContainerView(placeholder: String) -> UITextField {
-        let tf = UITextField()
-        tf.heightAnchor.constraint(equalToConstant: 55).isActive = true
-        tf.placeholder = placeholder
-        tf.borderStyle = .roundedRect
-        tf.font = UIFont.systemFont(ofSize: 16)
-        tf.attributedPlaceholder = NSAttributedString(string: placeholder, attributes: [NSAttributedString.Key.foregroundColor: UIColor.gray])
-        return tf
+        let textfield = UITextField()
+        textfield.heightAnchor.constraint(equalToConstant: 55).isActive = true
+        textfield.placeholder = placeholder
+        textfield.borderStyle = .roundedRect
+        textfield.font = UIFont.systemFont(ofSize: 16)
+        textfield.attributedPlaceholder = NSAttributedString(string: placeholder, attributes: [NSAttributedString.Key.foregroundColor: UIColor.gray])
+        return textfield
     }
 }

--- a/momoIOS/Authentication/Controller/LoginController.swift
+++ b/momoIOS/Authentication/Controller/LoginController.swift
@@ -40,7 +40,7 @@ class LoginController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
-        configureUI()
+        setupLayout()
         pushRegistrationViewButton.addTarget(self, action: #selector(handlePushRegistrationView), for: .touchUpInside)
         pushHelpLogin.addTarget(self, action: #selector(handlePushHelpLogin), for: .touchUpInside)
     }
@@ -67,26 +67,27 @@ class LoginController: UIViewController {
     
     // MARK: - Helpers
     
-    func configureUI() {
-        view.addSubview(welcomeTitle)
+    func setupLayout() {
+        let fieldStack = UIStackView(arrangedSubviews: [emailTextField, passwordTextField, loginButton])
+        fieldStack.axis = .vertical
+        fieldStack.spacing = 15
+        
+        let helpStack = UIStackView(arrangedSubviews: [pushRegistrationViewButton, pushHelpLogin])
+        helpStack.axis = .vertical
+        helpStack.spacing = 30
+        
+        view.addSubviews(welcomeTitle, fieldStack, helpStack)
+        
         welcomeTitle.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide).offset(50)
             make.left.equalTo(view).offset(20)
         }
         
-        let fieldStack = UIStackView(arrangedSubviews: [emailTextField, passwordTextField, loginButton])
-        fieldStack.axis = .vertical
-        fieldStack.spacing = 15
-        view.addSubview(fieldStack)
         fieldStack.snp.makeConstraints { make in
             make.top.equalTo(welcomeTitle.snp.bottom).offset(50)
             make.left.right.equalToSuperview().inset(20)
         }
         
-        let helpStack = UIStackView(arrangedSubviews: [pushRegistrationViewButton, pushHelpLogin])
-        helpStack.axis = .vertical
-        helpStack.spacing = 30
-        view.addSubview(helpStack)
         helpStack.snp.makeConstraints { make in
             make.top.equalTo(fieldStack.snp.bottom).offset(20)
             make.left.right.equalToSuperview().inset(20)

--- a/momoIOS/Authentication/Controller/LoginController.swift
+++ b/momoIOS/Authentication/Controller/LoginController.swift
@@ -52,6 +52,7 @@ class LoginController: UIViewController {
     // MARK: - Selectors
     
     @objc func handlePushRegistrationView() {
+        self.dismiss(animated: true)
     }
     
     @objc func handlePushHelpLogin() {

--- a/momoIOS/Authentication/Controller/LoginController.swift
+++ b/momoIOS/Authentication/Controller/LoginController.swift
@@ -1,0 +1,137 @@
+//
+//  LoginController.swift
+//  momoIOS
+//
+//  Created by 문다 on 2023/01/30.
+//
+
+import UIKit
+import SnapKit
+
+class LoginController: UIViewController {
+    // MARK: - Properties
+    
+    private let welcomeTitle: UILabel = {
+        let title = UILabel()
+        title.text = "간단한 출석체크,\n모두모여에서"
+        title.font = UIFont.systemFont(ofSize: 40, weight: .regular)
+        title.numberOfLines = 0
+        return title
+    }()
+    
+    private lazy var emailTextField: UITextField = {
+        return inputContainerView(placeholder: "이메일을 입력해주세요")
+    }()
+    
+    private lazy var passwordTextField: UITextField = {
+        return inputContainerView(placeholder: "비밀번호를 입력해주세요")
+    }()
+    
+    private let loginButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("로그인", for: .normal)
+        button.setTitleColor(UIColor.white, for: .normal)
+        button.backgroundColor = .black
+        button.heightAnchor.constraint(equalToConstant: 55).isActive = true
+        button.layer.cornerRadius = 5
+        button.titleLabel?.font = .boldSystemFont(ofSize: 18)
+        return button
+    }()
+    
+    private let pushRegistrationViewButton: UIButton = {
+        let button = UIButton(type: .system)
+        let attributedTitle = NSMutableAttributedString(
+            string: "회원가입이 필요하다면?",
+            attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16),
+                         NSAttributedString.Key.foregroundColor: UIColor.gray])
+        attributedTitle.append(NSAttributedString(
+            string: "  가입하기",
+            attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16),
+                         NSAttributedString.Key.foregroundColor: UIColor.black]))
+        button.setAttributedTitle(attributedTitle, for: .normal)
+        return button
+    }()
+    
+    private let pushHelpLogin: UIButton = {
+        let button = UIButton(type: .system)
+        let attributedTitle = NSMutableAttributedString(
+            string: "로그인에 문제가 있나요?",
+            attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16),
+                         NSAttributedString.Key.foregroundColor: UIColor.gray])
+        button.setAttributedTitle(attributedTitle, for: .normal)
+        return button
+    }()
+    
+    // MARK: - Lifecycles
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        configureUI()
+    }
+    
+    // MARK: - Selectors
+    
+    @objc func handlePushRegistrationView() {
+    }
+    
+    @objc func handlePushHelpLogin() {
+    }
+    
+    // MARK: - Helpers
+    
+    func configureUI() {
+        view.backgroundColor = .white
+        view.addSubview(welcomeTitle)
+        
+        welcomeTitle.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(50)
+            make.left.equalTo(view).offset(20)
+        }
+        
+        let stack = UIStackView(arrangedSubviews: [emailTextField, passwordTextField, loginButton])
+        stack.axis = .vertical
+        stack.spacing = 15
+        view.addSubview(stack)
+        stack.snp.makeConstraints { make in
+            make.top.equalTo(welcomeTitle.snp.bottom).offset(50)
+            make.left.equalTo(view).offset(20)
+            make.right.equalTo(view).offset(-20)
+        }
+        
+        view.addSubview(loginButton)
+        loginButton.snp.makeConstraints { make in
+            make.top.equalTo(stack.snp.bottom).offset(20)
+            make.left.equalTo(view).offset(20)
+            make.right.equalTo(view).offset(-20)
+        }
+        
+        view.addSubview(pushRegistrationViewButton)
+        pushRegistrationViewButton.snp.makeConstraints { make in
+            make.top.equalTo(loginButton.snp.bottom).offset(20)
+            make.left.right.equalToSuperview()
+        }
+        pushRegistrationViewButton.addTarget(self, action: #selector(handlePushRegistrationView), for: .touchUpInside)
+
+        view.addSubview(pushHelpLogin)
+        pushHelpLogin.snp.makeConstraints { make in
+            make.top.equalTo(pushRegistrationViewButton.snp.bottom).offset(30)
+            make.left.right.equalToSuperview()
+        }
+        pushHelpLogin.addTarget(self, action: #selector(handlePushHelpLogin), for: .touchUpInside)
+    }
+}
+
+// MARK: - Extension
+
+extension LoginController {
+    func inputContainerView(placeholder: String) -> UITextField {
+        let tf = UITextField()
+        tf.heightAnchor.constraint(equalToConstant: 55).isActive = true
+        tf.placeholder = placeholder
+        tf.borderStyle = .roundedRect
+        tf.font = UIFont.systemFont(ofSize: 16)
+        tf.attributedPlaceholder = NSAttributedString(string: placeholder, attributes: [NSAttributedString.Key.foregroundColor: UIColor.gray])
+        return tf
+    }
+}

--- a/momoIOS/Authentication/Controller/RegistrationController.swift
+++ b/momoIOS/Authentication/Controller/RegistrationController.swift
@@ -31,19 +31,23 @@ class RegistrationController: UIViewController {
         return pushAnotherViewButton(subtitle: "이미 가입했다면?", title: "로그인하기")
     }()
     
-
-    
     // MARK: - Lifecycles
     
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
         configureUI()
+        registrationButton.addTarget(self, action: #selector(handleRegistration), for: .touchUpInside)
         pushLoginViewButton.addTarget(self, action: #selector(handlePushLoginView), for: .touchUpInside)
         pushHelpLogin.addTarget(self, action: #selector(handlePushHelpLogin), for: .touchUpInside)
     }
     
     // MARK: - Selectors
+    
+    @objc func handleRegistration() {
+        let controller = CheckSecurityCodeController()
+        navigationController?.pushViewController(controller, animated: true)
+    }
     
     @objc func handlePushLoginView() {
     }

--- a/momoIOS/Authentication/Controller/RegistrationController.swift
+++ b/momoIOS/Authentication/Controller/RegistrationController.swift
@@ -23,7 +23,7 @@ class RegistrationController: UIViewController {
     }()
     
     private lazy var passwordTextField: UITextField = {
-        return inputContainerView(placeholder: "비밀번호를 입력해주세요")
+        return inputContainerView(placeholder: "비밀번호를 입력해주세요", isSecureField: true)
     }()
     
     private let validPasswordFormatLabel: UILabel = {
@@ -36,7 +36,7 @@ class RegistrationController: UIViewController {
     }()
     
     private lazy var checkPasswordTextField: UITextField = {
-        return inputContainerView(placeholder: "비밀번호를 재입력해주세요")
+        return inputContainerView(placeholder: "비밀번호를 재입력해주세요", isSecureField: true)
     }()
     
     private let confirmPasswordLabel: UILabel = {

--- a/momoIOS/Authentication/Controller/RegistrationController.swift
+++ b/momoIOS/Authentication/Controller/RegistrationController.swift
@@ -1,5 +1,5 @@
 //
-//  LoginController.swift
+//  RegistrationController.swift
 //  momoIOS
 //
 //  Created by 문다 on 2023/01/30.
@@ -8,16 +8,8 @@
 import UIKit
 import SnapKit
 
-class LoginController: UIViewController {
+class RegistrationController: UIViewController {
     // MARK: - Properties
-    
-    private let welcomeTitle: UILabel = {
-        let title = UILabel()
-        title.text = "간단한 출석체크,\n모두모여에서"
-        title.font = UIFont.systemFont(ofSize: 40, weight: .regular)
-        title.numberOfLines = 0
-        return title
-    }()
     
     private lazy var emailTextField: UITextField = {
         return inputContainerView(placeholder: "이메일을 입력해주세요")
@@ -27,13 +19,19 @@ class LoginController: UIViewController {
         return inputContainerView(placeholder: "비밀번호를 입력해주세요")
     }()
     
-    private let loginButton: UIButton = {
-        return actionButton(title: "로그인")
+    private lazy var checkPasswordTextField: UITextField = {
+        return inputContainerView(placeholder: "비밀번호를 재입력해주세요")
     }()
     
-    private let pushRegistrationViewButton: UIButton = {
-        return pushAnotherViewButton(subtitle: "회원가입이 필요하다면?", title: "가입하기")
+    private let registrationButton: UIButton = {
+        return actionButton(title: "가입하기")
     }()
+    
+    private let pushLoginViewButton: UIButton = {
+        return pushAnotherViewButton(subtitle: "이미 가입했다면?", title: "로그인하기")
+    }()
+    
+
     
     // MARK: - Lifecycles
     
@@ -41,13 +39,13 @@ class LoginController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .white
         configureUI()
-        pushRegistrationViewButton.addTarget(self, action: #selector(handlePushRegistrationView), for: .touchUpInside)
+        pushLoginViewButton.addTarget(self, action: #selector(handlePushLoginView), for: .touchUpInside)
         pushHelpLogin.addTarget(self, action: #selector(handlePushHelpLogin), for: .touchUpInside)
     }
     
     // MARK: - Selectors
     
-    @objc func handlePushRegistrationView() {
+    @objc func handlePushLoginView() {
     }
     
     @objc func handlePushHelpLogin() {
@@ -62,7 +60,7 @@ class LoginController: UIViewController {
             make.left.equalTo(view).offset(20)
         }
         
-        let fieldStack = UIStackView(arrangedSubviews: [emailTextField, passwordTextField, loginButton])
+        let fieldStack = UIStackView(arrangedSubviews: [emailTextField, passwordTextField, checkPasswordTextField, registrationButton])
         fieldStack.axis = .vertical
         fieldStack.spacing = 15
         view.addSubview(fieldStack)
@@ -71,7 +69,7 @@ class LoginController: UIViewController {
             make.left.right.equalToSuperview().inset(20)
         }
         
-        let helpStack = UIStackView(arrangedSubviews: [pushRegistrationViewButton, pushHelpLogin])
+        let helpStack = UIStackView(arrangedSubviews: [pushLoginViewButton, pushHelpLogin])
         helpStack.axis = .vertical
         helpStack.spacing = 30
         view.addSubview(helpStack)

--- a/momoIOS/Authentication/Controller/RegistrationController.swift
+++ b/momoIOS/Authentication/Controller/RegistrationController.swift
@@ -15,12 +15,36 @@ class RegistrationController: UIViewController {
         return inputContainerView(placeholder: "이메일을 입력해주세요")
     }()
     
+    private let validEmailFormatLabel: UILabel = {
+        let label = UILabel()
+        label.text = "넥스터즈 가입 메일주소를 입력해주세요"
+        label.font = .systemFont(ofSize: 13)
+        return label
+    }()
+    
     private lazy var passwordTextField: UITextField = {
         return inputContainerView(placeholder: "비밀번호를 입력해주세요")
     }()
     
+    private let validPasswordFormatLabel: UILabel = {
+        let label = UILabel()
+        label.text = ""
+        label.font = .systemFont(ofSize: 13)
+        label.textColor = .rgba(255, 38, 38, 1)
+        label.numberOfLines = 0
+        return label
+    }()
+    
     private lazy var checkPasswordTextField: UITextField = {
         return inputContainerView(placeholder: "비밀번호를 재입력해주세요")
+    }()
+    
+    private let confirmPasswordLabel: UILabel = {
+        let label = UILabel()
+        label.text = ""
+        label.font = .systemFont(ofSize: 13)
+        label.textColor = .rgba(255, 38, 38, 1)
+        return label
     }()
     
     private let registrationButton: UIButton = {
@@ -36,6 +60,7 @@ class RegistrationController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
+        setupTargets()
         configureUI()
         registrationButton.addTarget(self, action: #selector(handleRegistration), for: .touchUpInside)
         pushLoginViewButton.addTarget(self, action: #selector(handlePushLoginView), for: .touchUpInside)
@@ -47,6 +72,57 @@ class RegistrationController: UIViewController {
         }
     
     // MARK: - Selectors
+    
+    func isValidEmail(email: String) -> Bool {
+           let emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
+           return NSPredicate(format: "SELF MATCHES %@", emailRegEx).evaluate(with: email)
+    }
+    
+    @objc private func emailTextFieldDidChange(_ textField: UITextField) {
+        guard let email = textField.text else { return }
+        
+        if !isValidEmail(email: email) {
+            if email.count == 0 {
+                validEmailFormatLabel.text = "넥스터즈 가입 메일주소를 입력해주세요"
+                validEmailFormatLabel.textColor = .black
+            } else {
+                validEmailFormatLabel.text = "이메일 형식을 확인해주세요"
+                validEmailFormatLabel.textColor = .rgba(255, 38, 38, 1)
+            }
+        } else {
+            validEmailFormatLabel.text = ""
+        }
+    }
+    
+    func isValidPassword(password: String) -> Bool {
+        let passwordRegEx = "^(?=.*[A-Za-z])(?=.*[0-9]).{8,20}"
+        return NSPredicate(format: "SELF MATCHES %@", passwordRegEx).evaluate(with: password)
+    }
+    
+    @objc private func passwordTextFieldDidChange(_ textField: UITextField) {
+        guard let password = textField.text else { return }
+        
+        if !isValidPassword(password: password) {
+            if password.count == 0 {
+                confirmPasswordLabel.text = ""
+            } else {
+                validPasswordFormatLabel.text = "비밀번호 형식을 확인해주세요\n알파벳+숫자 필수 포함, 특수문자 가능 (8~20자)"
+            }
+        } else {
+            validPasswordFormatLabel.text = ""
+        }
+    }
+    
+    @objc private func confirmPassword(_ textField: UITextField) {
+        guard let password = passwordTextField.text else { return }
+        guard let checkPassword = checkPasswordTextField.text else { return }
+        
+        if password == checkPassword {
+            confirmPasswordLabel.text = ""
+        } else {
+            confirmPasswordLabel.text = "비밀번호가 일치하지 않습니다."
+        }
+    }
     
     @objc func handleRegistration() {
         let controller = CheckSecurityCodeController()
@@ -71,6 +147,24 @@ class RegistrationController: UIViewController {
     
     // MARK: - Helpers
     
+    private func setupTargets() {
+        emailTextField.addTarget(self, action: #selector(emailTextFieldDidChange(_:)), for: .editingChanged)
+        passwordTextField.addTarget(self, action: #selector(passwordTextFieldDidChange(_:)), for: .editingChanged)
+        checkPasswordTextField.addTarget(self, action: #selector(confirmPassword(_:)), for: .editingChanged)
+    }
+    
+    private func setupEmailContainerView() -> UIStackView {
+        return setupUIStackView([emailTextField, validEmailFormatLabel])
+    }
+    
+    private func setupPasswordTextFieldView() -> UIStackView {
+        return setupUIStackView([passwordTextField, validPasswordFormatLabel])
+    }
+    
+    private func setupCheckPasswordTextFieldView() -> UIStackView {
+        return setupUIStackView([checkPasswordTextField, confirmPasswordLabel])
+    }
+    
     func configureUI() {
         view.addSubview(welcomeTitle)
         welcomeTitle.snp.makeConstraints { make in
@@ -78,9 +172,13 @@ class RegistrationController: UIViewController {
             make.left.equalTo(view).offset(20)
         }
         
-        let fieldStack = UIStackView(arrangedSubviews: [emailTextField, passwordTextField, checkPasswordTextField, registrationButton])
+        let emailContainerView = setupEmailContainerView()
+        let passwordContainerView = setupPasswordTextFieldView()
+        let checkPasswordContainerView = setupCheckPasswordTextFieldView()
+
+        let fieldStack = UIStackView(arrangedSubviews: [emailContainerView, passwordContainerView, checkPasswordContainerView, registrationButton])
         fieldStack.axis = .vertical
-        fieldStack.spacing = 15
+        fieldStack.spacing = 10
         view.addSubview(fieldStack)
         fieldStack.snp.makeConstraints { make in
             make.top.equalTo(welcomeTitle.snp.bottom).offset(50)

--- a/momoIOS/Authentication/Controller/RegistrationController.swift
+++ b/momoIOS/Authentication/Controller/RegistrationController.swift
@@ -42,6 +42,10 @@ class RegistrationController: UIViewController {
         pushHelpLogin.addTarget(self, action: #selector(handlePushHelpLogin), for: .touchUpInside)
     }
     
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+            self.view.endEditing(true)
+        }
+    
     // MARK: - Selectors
     
     @objc func handleRegistration() {

--- a/momoIOS/Authentication/Controller/RegistrationController.swift
+++ b/momoIOS/Authentication/Controller/RegistrationController.swift
@@ -54,6 +54,9 @@ class RegistrationController: UIViewController {
     }
     
     @objc func handlePushLoginView() {
+        let nav = UINavigationController(rootViewController: LoginController())
+        nav.modalPresentationStyle = .fullScreen
+        self.present(nav, animated: true, completion: nil)
     }
     
     @objc func handlePushHelpLogin() {

--- a/momoIOS/Authentication/Controller/RegistrationController.swift
+++ b/momoIOS/Authentication/Controller/RegistrationController.swift
@@ -63,6 +63,7 @@ class RegistrationController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
+        self.navigationController?.navigationBar.isHidden = true
         self.setupTargets()
         self.setupLayout()
         self.registrationButton.addTarget(self, action: #selector(handleRegistration), for: .touchUpInside)
@@ -173,11 +174,7 @@ class RegistrationController: UIViewController {
         let passwordContainerView = setupPasswordTextFieldView()
         let checkPasswordContainerView = setupCheckPasswordTextFieldView()
         
-        fieldStack.addArrangedSubview(emailContainerView)
-        fieldStack.addArrangedSubview(passwordContainerView)
-        fieldStack.addArrangedSubview(checkPasswordContainerView)
-        fieldStack.addArrangedSubview(registrationButton)
-        
+        fieldStack.addArrangedSubviews(emailContainerView, passwordContainerView, checkPasswordContainerView, registrationButton)
         fieldStack.axis = .vertical
         fieldStack.spacing = 10
         

--- a/momoIOS/Authentication/Controller/RegistrationController.swift
+++ b/momoIOS/Authentication/Controller/RegistrationController.swift
@@ -60,6 +60,13 @@ class RegistrationController: UIViewController {
     }
     
     @objc func handlePushHelpLogin() {
+        // TODO: 로그인 가이드 url 변경 필요
+        guard let url = URL(string: "https://www.google.co.kr/") else { return }
+        if #available(iOS 10.0, *) {
+            UIApplication.shared.open(url, options: [:])
+        } else {
+            UIApplication.shared.openURL(url)
+        }
     }
     
     // MARK: - Helpers

--- a/momoIOS/Authentication/Controller/RegistrationController.swift
+++ b/momoIOS/Authentication/Controller/RegistrationController.swift
@@ -55,21 +55,24 @@ class RegistrationController: UIViewController {
         return pushAnotherViewButton(subtitle: "이미 가입했다면?", title: "로그인하기")
     }()
     
+    private let fieldStack = UIStackView()
+    private let helpStack = UIStackView()
+    
     // MARK: - Lifecycles
     
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
-        setupTargets()
-        configureUI()
-        registrationButton.addTarget(self, action: #selector(handleRegistration), for: .touchUpInside)
-        pushLoginViewButton.addTarget(self, action: #selector(handlePushLoginView), for: .touchUpInside)
+        self.setupTargets()
+        self.setupLayout()
+        self.registrationButton.addTarget(self, action: #selector(handleRegistration), for: .touchUpInside)
+        self.pushLoginViewButton.addTarget(self, action: #selector(handlePushLoginView), for: .touchUpInside)
         pushHelpLogin.addTarget(self, action: #selector(handlePushHelpLogin), for: .touchUpInside)
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
             self.view.endEditing(true)
-        }
+    }
     
     // MARK: - Selectors
     
@@ -94,7 +97,7 @@ class RegistrationController: UIViewController {
         }
     }
     
-    func isValidPassword(password: String) -> Bool {
+    private func isValidPassword(password: String) -> Bool {
         let passwordRegEx = "^(?=.*[A-Za-z])(?=.*[0-9]).{8,20}"
         return NSPredicate(format: "SELF MATCHES %@", passwordRegEx).evaluate(with: password)
     }
@@ -124,18 +127,18 @@ class RegistrationController: UIViewController {
         }
     }
     
-    @objc func handleRegistration() {
+    @objc private func handleRegistration() {
         let controller = CheckSecurityCodeController()
         navigationController?.pushViewController(controller, animated: true)
     }
     
-    @objc func handlePushLoginView() {
+    @objc private func handlePushLoginView() {
         let nav = UINavigationController(rootViewController: LoginController())
         nav.modalPresentationStyle = .fullScreen
         self.present(nav, animated: true, completion: nil)
     }
     
-    @objc func handlePushHelpLogin() {
+    @objc private func handlePushHelpLogin() {
         // TODO: 로그인 가이드 url 변경 필요
         guard let url = URL(string: "https://www.google.co.kr/") else { return }
         if #available(iOS 10.0, *) {
@@ -165,30 +168,38 @@ class RegistrationController: UIViewController {
         return setupUIStackView([checkPasswordTextField, confirmPasswordLabel])
     }
     
-    func configureUI() {
-        view.addSubview(welcomeTitle)
+    private func setupViews() {
+        let emailContainerView = setupEmailContainerView()
+        let passwordContainerView = setupPasswordTextFieldView()
+        let checkPasswordContainerView = setupCheckPasswordTextFieldView()
+        
+        fieldStack.addArrangedSubview(emailContainerView)
+        fieldStack.addArrangedSubview(passwordContainerView)
+        fieldStack.addArrangedSubview(checkPasswordContainerView)
+        fieldStack.addArrangedSubview(registrationButton)
+        
+        fieldStack.axis = .vertical
+        fieldStack.spacing = 10
+        
+        helpStack.addArrangedSubviews(pushLoginViewButton, pushHelpLogin)
+        helpStack.axis = .vertical
+        helpStack.spacing = 30
+        
+        view.addSubviews(welcomeTitle, fieldStack, helpStack)
+    }
+    
+    private func setupLayout() {
+        setupViews()
         welcomeTitle.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide).offset(50)
             make.left.equalTo(view).offset(20)
         }
         
-        let emailContainerView = setupEmailContainerView()
-        let passwordContainerView = setupPasswordTextFieldView()
-        let checkPasswordContainerView = setupCheckPasswordTextFieldView()
-
-        let fieldStack = UIStackView(arrangedSubviews: [emailContainerView, passwordContainerView, checkPasswordContainerView, registrationButton])
-        fieldStack.axis = .vertical
-        fieldStack.spacing = 10
-        view.addSubview(fieldStack)
         fieldStack.snp.makeConstraints { make in
             make.top.equalTo(welcomeTitle.snp.bottom).offset(50)
             make.left.right.equalToSuperview().inset(20)
         }
-        
-        let helpStack = UIStackView(arrangedSubviews: [pushLoginViewButton, pushHelpLogin])
-        helpStack.axis = .vertical
-        helpStack.spacing = 30
-        view.addSubview(helpStack)
+
         helpStack.snp.makeConstraints { make in
             make.top.equalTo(fieldStack.snp.bottom).offset(20)
             make.left.right.equalToSuperview().inset(20)

--- a/momoIOS/ViewController.swift
+++ b/momoIOS/ViewController.swift
@@ -23,7 +23,7 @@ class ViewController: UIViewController {
     // MARK: - Setup
     private func setupViews() {
         self.mainButton.setTitle("Main으로 이동", for: .normal)
-        self.otherButton.setTitle("...으로 이동", for: .normal)
+        self.otherButton.setTitle("가입화면으로 이동", for: .normal)
         
         let stackView = UIStackView()
         stackView.axis = .vertical

--- a/momoIOS/ViewController.swift
+++ b/momoIOS/ViewController.swift
@@ -47,6 +47,6 @@ class ViewController: UIViewController {
     }
     
     @objc private func goToOtherViewController() {
-//        self.navigationController?.pushViewController(MainViewController(), animated: true)
+        self.navigationController?.pushViewController(RegistrationController(), animated: true)
     }
 }


### PR DESCRIPTION
close #2 
사용자 인증 (로그인, 회원가입) view를 구현했습니다 

다음에는 로그인 / 회원가입 식으로 나누어 잘게 커밋해야겠읍니다 ... 😞
왜인지 모르겠지만 pull 받으면서 커밋 시간이 모두 바꼈어요 .. 😵‍💫

## Changes
- 로그인 view
- 회원가입 view
  - 보안코드 입력 view
  - 회원정보 입력 view
  - 각 텍스트필드값을 감지하여 텍스트에 대한 예외 처리
- `"로그인에 문제가 있나요?"` 버튼 클릭시 연결된 링크에 사파리로 이동 (현재는 임시로 www.google.co.kr)
- 화면이동 로직

+ ViewController의 other 버튼을 누르면 회원가입뷰로 이동

## TODO
- ViewModel 연동 
- 로그인 가이드 url 변경
- 화면 이동이 제대로 구현된 것이 맞는지 확인

<img width="250" alt="스크린샷 2023-01-30 오전 2 36 55" src="https://user-images.githubusercontent.com/57654681/216561119-f74d6fb4-3a98-46c6-aaa1-88f8e7928d88.png"><img width="250" alt="스크린샷 2023-02-01 오후 11 07 18" src="https://user-images.githubusercontent.com/57654681/216561139-5044e615-681a-402b-b9a3-05725e9403b6.png">
<img width="250" alt="스크린샷 2023-02-01 오후 11 07 51" src="https://user-images.githubusercontent.com/57654681/216561145-4a5626dc-fae9-4822-8f02-e14a2ba90c95.png"><img width="250" alt="스크린샷 2023-02-02 오후 11 54 40" src="https://user-images.githubusercontent.com/57654681/216561148-66fc0fbf-2180-42cd-a5a0-be2415b2aa1a.png">

좌: 회원가입시 동작 과정
우: 로그인화면 + "로그인에 문제가 있나요?" 버튼 클릭시
![Simulator Screen Recording - iPhone 14 Pro - 2023-02-02 at 23 55 43](https://user-images.githubusercontent.com/57654681/216561136-5250d8cb-41ec-4adf-8115-87dca420f198.gif)  ![Simulator Screen Recording - iPhone 14 Pro - 2023-02-02 at 23 56 25](https://user-images.githubusercontent.com/57654681/216561152-db9d90f8-db72-4820-be95-bce0ea0a49a2.gif)
