### PR TITLE
[FIX] MainVC에서 히스토리 버튼 선택 시 화면 전환 로직 추가

### DIFF
--- a/momoIOS/MainAttendanceCodeCell.swift
+++ b/momoIOS/MainAttendanceCodeCell.swift
@@ -9,6 +9,7 @@ import UIKit
 import SnapKit
 
 class MainAttendanceCodeCell: UITableViewCell {
+    private let cardView: UIView = UIView()
     private let titleLabel: UILabel = UILabel()
     private let codeStackView: UIStackView = UIStackView()
     private let descriptionLabel: UILabel = UILabel()
@@ -17,6 +18,7 @@ class MainAttendanceCodeCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: "MainAttendanceCodeCell")
         
+        self.selectionStyle = .none
         self.setupViews()
         self.setupLayout()
     }
@@ -28,13 +30,14 @@ class MainAttendanceCodeCell: UITableViewCell {
     // MARK: - Setup
     private func setupViews() {
         // TODO: ViewModel 바라보도록 수정 필요
-        self.contentView.backgroundColor = .darkGray
-        self.contentView.layer.cornerRadius = 12
+        self.cardView.backgroundColor = .rgba(128, 135, 201, 1)
+        self.cardView.layer.cornerRadius = 12
+        self.contentView.addSubview(self.cardView)
         
         self.titleLabel.text = "출석체크 코드 입력"
         self.titleLabel.font = .systemFont(ofSize: 17, weight: .medium)
         self.titleLabel.textColor = .white
-        self.contentView.addSubview(self.titleLabel)
+        self.cardView.addSubview(self.titleLabel)
         
         self.codeStackView.axis = .horizontal
         self.codeStackView.alignment = .center
@@ -44,16 +47,22 @@ class MainAttendanceCodeCell: UITableViewCell {
             lineView.backgroundColor = .white
             self.codeStackView.addArrangedSubview(lineView)
         }
-        self.contentView.addSubview(self.codeStackView)
+        self.cardView.addSubview(self.codeStackView)
         
         self.descriptionLabel.text = "운영진이 공지해준 출석체크 코드를 입력해주세요!"
         self.descriptionLabel.font = .systemFont(ofSize: 14)
-        self.descriptionLabel.textColor = .lightGray
-        self.contentView.addSubview(self.descriptionLabel)
+        self.descriptionLabel.textColor = .white.withAlphaComponent(0.67)
+        self.cardView.addSubview(self.descriptionLabel)
     }
     
     // MARK: - Layout
     private func setupLayout() {
+        self.cardView.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.leading.trailing.equalToSuperview().inset(24)
+            make.bottom.equalToSuperview().inset(19)
+        }
+        
         self.titleLabel.snp.makeConstraints { make in
             make.top.equalToSuperview().inset(28)
             make.centerX.equalToSuperview()

--- a/momoIOS/MainAttendanceDoneCell.swift
+++ b/momoIOS/MainAttendanceDoneCell.swift
@@ -9,6 +9,7 @@ import UIKit
 import SnapKit
 
 class MainAttendanceDoneCell: UITableViewCell {
+    private let cardView: UIView = UIView()
     private var iconImageView: UIImageView = UIImageView()
     private let titleLabel: UILabel = UILabel()
     private let timeStatusContainerView: UIView = UIView()
@@ -23,6 +24,7 @@ class MainAttendanceDoneCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: "MainAttendanceDoneCell")
         
+        self.selectionStyle = .none
         self.setupViews()
         self.setupLayout()
     }
@@ -34,8 +36,9 @@ class MainAttendanceDoneCell: UITableViewCell {
     // MARK: - Setup
     // TODO: ViewModel 바라보도록 수정 필요
     private func setupViews() {
-        self.contentView.backgroundColor = .brown
-        self.contentView.layer.cornerRadius = 12
+        self.cardView.backgroundColor = .rgba(128, 135, 201, 1)
+        self.cardView.layer.cornerRadius = 12
+        self.contentView.addSubview(self.cardView)
 
         self.setupIconImageView()
         self.setupTitleLabel()
@@ -48,14 +51,14 @@ class MainAttendanceDoneCell: UITableViewCell {
         let checkImage = UIImage(systemName: "checkmark.circle")
         self.iconImageView.image = checkImage
         self.iconImageView.tintColor = .white
-        self.contentView.addSubview(self.iconImageView)
+        self.cardView.addSubview(self.iconImageView)
     }
     
     private func setupTitleLabel() {
         self.titleLabel.text = "출석이 완료되었습니다"
         self.titleLabel.font = .systemFont(ofSize: 17, weight: .medium)
         self.titleLabel.textColor = .white
-        self.contentView.addSubview(self.titleLabel)
+        self.cardView.addSubview(self.titleLabel)
     }
     
     private func setupTimeStatusViews() {
@@ -69,25 +72,31 @@ class MainAttendanceDoneCell: UITableViewCell {
         self.statusLabel.textColor = .white
         self.timeStatusContainerView.addSubview(self.statusLabel)
         
-        self.contentView.addSubview(self.timeStatusContainerView)
+        self.cardView.addSubview(self.timeStatusContainerView)
     }
     
     private func setupScoreLabel() {
         self.scoreLabel.text = "(-5점이 감점되었습니다)"
         self.scoreLabel.font = .systemFont(ofSize: 13, weight: .regular)
         self.scoreLabel.textColor = .white
-        self.contentView.addSubview(self.scoreLabel)
+        self.cardView.addSubview(self.scoreLabel)
     }
     
     private func setupHistoryButton() {
         self.historyButton.addTarget(self, action: #selector(didTapHistoryButton), for: .touchUpInside)
         self.historyButton.setTitle("출석 히스토리", size: 12, weight: .medium, color: .white)
         self.historyButton.configurate(bgColor: .white.withAlphaComponent(0.14), cornerRadius: 6, padding: 10)
-        self.contentView.addSubview(self.historyButton)        
+        self.cardView.addSubview(self.historyButton)        
     }
     
     // MARK: - Layout
     private func setupLayout() {
+        self.cardView.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.leading.trailing.equalToSuperview().inset(24)
+            make.bottom.equalToSuperview().inset(19)
+        }
+        
         self.iconImageView.snp.makeConstraints { make in
             make.top.equalToSuperview().inset(31)
             make.size.equalTo(42)

--- a/momoIOS/MainViewController.swift
+++ b/momoIOS/MainViewController.swift
@@ -69,10 +69,6 @@ class MainViewController: UIViewController {
         self.navigationController?.popViewController(animated: true)
     }
     
-    private func goToHistoryVC() {
-        self.navigationController?.popViewController(animated: true)
-    }
-    
     private func showAbsenceModal() {
         let absenceModal = AbsenceModalViewController()
         absenceModal.modalPresentationStyle = .overFullScreen
@@ -104,7 +100,7 @@ extension MainViewController: UITableViewDelegate, UITableViewDataSource {
                 return UITableViewCell()
             }
             cell.historyButtonAction = { [weak self] in
-                self?.goToHistoryVC()
+                self?.goToUserProfileVC()
             }
             return cell
         case 3:
@@ -126,7 +122,7 @@ extension MainViewController: UITableViewDelegate, UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         switch indexPath.section {
-        case 0: // (MainAttendanceCodeCell) 출석 코드 입력 셀
+        case 1: // (MainAttendanceCodeCell) 출석 코드 입력 셀
             self.goToAttendanceVC()
         default:
             break


### PR DESCRIPTION
* MainVC에서 MainAttendanceCodeCell 클릭시 이동 로직 추가 (임시로 dismiss)
* MainVC에서 MainAttendanceDoneCell 히스토리 버튼 클릭 시 마이페이지로 이동 로직 추가
* 수정하는 김에 디자인도 와이어프레임에 맞게 변경했습니다~!

<img src="https://user-images.githubusercontent.com/37800715/216752919-ae1adc8d-e643-4009-80af-7ffad531e250.png" width="300"/>