### PR TITLE
[FIX][#37] MainSessionCell identifier 수정

### DIFF
--- a/MainSession/MainSessionAbsentCell.swift
+++ b/MainSession/MainSessionAbsentCell.swift
@@ -15,7 +15,7 @@ class MainSessionAbsentCell: UITableViewCell {
     var seesionAbsentBtnAction: (() -> Void)?
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: "MainSessionTimeCell")
+        super.init(style: style, reuseIdentifier: "MainSessionAbsentCell")
         self.initViews()
         self.setConstraints()
     }

--- a/MainSession/MainSessionInfoCell.swift
+++ b/MainSession/MainSessionInfoCell.swift
@@ -20,7 +20,7 @@ class MainSessionInfoCell: UITableViewCell {
     let moreDetailBtn = UIButton()
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: "MainSessionTimeCell")
+        super.init(style: style, reuseIdentifier: "MainSessionInfoCell")
         self.initViews()
         self.setViewConstraints()
         self.setLabelConstraints()


### PR DESCRIPTION
MainSessionAbsentCell identifier 수정했습니다
혹시나 해서 다른것도 확인해보니까 MainSessionInfoCell도 재사용 식별자 잘못되어있길래 수정했어용

<img width="795" alt="스크린샷 2023-02-09 오전 12 48 20" src="https://user-images.githubusercontent.com/63590121/217580029-1e7991ea-d273-47b9-8627-90d426bf600d.png">
<img width="795" alt="스크린샷 2023-02-09 오전 12 48 14" src="https://user-images.githubusercontent.com/63590121/217580047-fca3e612-167c-4308-b7ee-be3b67a1d87b.png">
