### PR TITLE
[FEAT][#34] 모임 관리 View 구현

### DIFF
--- a/PersonalInformation/PersonalInformationController.swift
+++ b/PersonalInformation/PersonalInformationController.swift
@@ -18,78 +18,13 @@ class PersonalInformationController: UIViewController {
                         2: ("결석", 0, -30)]
     // indexPath.row: (title.text, result.text, score?.text)
     
-    private let username = "김넥터"
-    private let userJob = "designer"
-    private let userYear = 22
-    private let email = "nexters@naver.com"
-    
+    private let profileView = ProfileView()
     private let historyTableView = UITableView()
     private let resultCollectionContainerView = UIView()
     private let resultCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout.init())
     
     private lazy var hintLatePenalty = setupHintPenalty("-5점")
     private lazy var hintAbsentPenalty = setupHintPenalty("통보 -10 / 무단 -15")
-    
-    private lazy var profileImageView: UIImageView = {
-        let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: 93, height: 93))
-        imageView.image = UIImage(named: "\(userJob)")!
-        imageView.contentMode = .scaleAspectFill
-        imageView.layer.cornerRadius = 93 / 2
-        imageView.clipsToBounds = true
-        imageView.layer.borderWidth = 1
-        imageView.layer.borderColor = UIColor.rgba(208, 208, 208, 1).cgColor
-        
-        return imageView
-    }()
-    
-    private lazy var userActiveStatus: UIView = {
-        let statusView = UIView()
-        
-        let status = UILabel()
-        status.text = "\(userYear)기 참여중"
-        status.font = .systemFont(ofSize: 13, weight: .bold)
-        status.textColor = .white
-        
-        statusView.addSubview(status)
-        status.snp.makeConstraints { make in
-            make.edges.equalTo(statusView).inset(9)
-        }
-        statusView.backgroundColor = UIColor.rgba(116, 207, 130, 1)
-        statusView.layer.cornerRadius = 5
-        return statusView
-    }()
-    
-    private lazy var userBasicInfomationView: UIStackView = {
-        let usernameLabel = UILabel()
-        let jobLabel = UILabel()
-        let jobLabelView = UIView()
-        let view = UIStackView(arrangedSubviews: [usernameLabel, jobLabelView])
-        view.axis = .horizontal
-        view.spacing = 10
-        
-        usernameLabel.text = username
-        usernameLabel.font = .systemFont(ofSize: 22, weight: .medium)
-        usernameLabel.textColor = .black
-        
-        jobLabel.text = userJob.uppercased()
-        jobLabel.font = .systemFont(ofSize: 13)
-        jobLabelView.addSubview(jobLabel)
-        jobLabel.snp.makeConstraints { make in
-            make.verticalEdges.equalTo(jobLabelView).inset(5)
-            make.horizontalEdges.equalTo(jobLabelView).inset(10)
-        }
-        jobLabelView.backgroundColor = UIColor.rgba(243, 243, 243, 1)
-        
-        return view
-    }()
-    
-    private lazy var userAdditionalInformationView: UILabel = {
-        let label = UILabel()
-        label.text = email
-        label.font = .systemFont(ofSize: 16)
-        label.textColor = UIColor.rgba(118, 118, 118, 1)
-        return label
-    }()
     
     private lazy var tableViewHeader: UIView = {
         let header = UIView(frame: CGRect(x: 0, y: 0, width: view.frame.size.width, height: 38))
@@ -154,10 +89,6 @@ class PersonalInformationController: UIViewController {
         logout.font = .systemFont(ofSize: 15)
         navigationItem.rightBarButtonItem = UIBarButtonItem(customView: logout)
     }
-
-    private func setupUserProfileImage() {
-        view.addSubviews(profileImageView, userActiveStatus, userBasicInfomationView, userAdditionalInformationView)
-    }
     
     private func setupHintPenalty(_ hint: String) -> UILabel {
         let hintLabel = UILabel()
@@ -195,7 +126,7 @@ class PersonalInformationController: UIViewController {
     }
     
     private func setupViews() {
-        setupUserProfileImage()
+        view.addSubview(profileView)
         setupResultCollectionView()
         setupHistoryTableView()
     }
@@ -203,27 +134,15 @@ class PersonalInformationController: UIViewController {
     private func setupLayout() {
         setupViews()
         
-        profileImageView.snp.makeConstraints { make in
-            make.top.equalTo(view.safeAreaLayoutGuide).offset(36)
+        profileView.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(10)
             make.centerX.equalToSuperview()
-        }
-        userActiveStatus.snp.makeConstraints { make in
-            make.top.equalTo(profileImageView.snp.centerY).offset(10)
-            make.left.equalTo(profileImageView.snp.centerX).offset(10)
-        }
-        
-        userBasicInfomationView.snp.makeConstraints { make in
-            make.top.equalTo(profileImageView.snp.bottom).offset(20)
-            make.centerX.equalToSuperview()
-        }
-        userAdditionalInformationView.snp.makeConstraints { make in
-            make.top.equalTo(userBasicInfomationView.snp.bottom).offset(10)
-            make.centerX.equalToSuperview()
+            make.height.equalTo(200)
         }
         
         resultCollectionContainerView.snp.makeConstraints { make in
             make.horizontalEdges.equalToSuperview()
-            make.top.equalTo(userAdditionalInformationView.snp.bottom).offset(27)
+            make.top.equalTo(profileView.snp.bottom).offset(20)
             make.height.equalTo(135)
         }
         

--- a/momoIOS.xcodeproj/project.pbxproj
+++ b/momoIOS.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		BF4310FA298C525900270DBF /* AttendanceHistoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4310F9298C525900270DBF /* AttendanceHistoryCell.swift */; };
 		BF43B57629951EAF0026DCE3 /* MoimManagementController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF43B57529951EAF0026DCE3 /* MoimManagementController.swift */; };
 		BF43B57829951F0C0026DCE3 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF43B57729951F0C0026DCE3 /* ProfileView.swift */; };
+		BF43B57A29952AFF0026DCE3 /* MoimSettingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF43B57929952AFF0026DCE3 /* MoimSettingCell.swift */; };
 		BF6EC77F298D1B2E00F4B170 /* AttendanceResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF6EC77E298D1B2E00F4B170 /* AttendanceResultCell.swift */; };
 		BF9988FC298AD04E005723C7 /* PersonalInformationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9988FB298AD04E005723C7 /* PersonalInformationController.swift */; };
 		BF998900298BB0D3005723C7 /* InputMemberInfoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9988FF298BB0D3005723C7 /* InputMemberInfoController.swift */; };
@@ -53,6 +54,7 @@
 		BF4310F9298C525900270DBF /* AttendanceHistoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttendanceHistoryCell.swift; sourceTree = "<group>"; };
 		BF43B57529951EAF0026DCE3 /* MoimManagementController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoimManagementController.swift; sourceTree = "<group>"; };
 		BF43B57729951F0C0026DCE3 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
+		BF43B57929952AFF0026DCE3 /* MoimSettingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoimSettingCell.swift; sourceTree = "<group>"; };
 		BF6EC77E298D1B2E00F4B170 /* AttendanceResultCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttendanceResultCell.swift; sourceTree = "<group>"; };
 		BF9988FB298AD04E005723C7 /* PersonalInformationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalInformationController.swift; sourceTree = "<group>"; };
 		BF9988FF298BB0D3005723C7 /* InputMemberInfoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputMemberInfoController.swift; sourceTree = "<group>"; };
@@ -111,6 +113,7 @@
 			isa = PBXGroup;
 			children = (
 				BF43B57529951EAF0026DCE3 /* MoimManagementController.swift */,
+				BF43B57929952AFF0026DCE3 /* MoimSettingCell.swift */,
 			);
 			path = Management;
 			sourceTree = "<group>";
@@ -313,6 +316,7 @@
 				BF43B57629951EAF0026DCE3 /* MoimManagementController.swift in Sources */,
 				3AA713D1298946FF006F922F /* UIColor+Extension.swift in Sources */,
 				3AA713C929884007006F922F /* MainAttendanceDoneCell.swift in Sources */,
+				BF43B57A29952AFF0026DCE3 /* MoimSettingCell.swift in Sources */,
 				E820792F298A138500B36FC9 /* MainSessionAbsentCell.swift in Sources */,
 				BF4310FA298C525900270DBF /* AttendanceHistoryCell.swift in Sources */,
 			);

--- a/momoIOS.xcodeproj/project.pbxproj
+++ b/momoIOS.xcodeproj/project.pbxproj
@@ -17,7 +17,7 @@
 		BF04086D2987E38C00F1129B /* RegistrationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086C2987E38C00F1129B /* RegistrationController.swift */; };
 		BF04086F2987E70200F1129B /* CheckSecurityCodeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086E2987E70200F1129B /* CheckSecurityCodeController.swift */; };
 		BF4310FA298C525900270DBF /* AttendanceHistoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4310F9298C525900270DBF /* AttendanceHistoryCell.swift */; };
-		BF43B57629951EAF0026DCE3 /* MoimManageController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF43B57529951EAF0026DCE3 /* MoimManageController.swift */; };
+		BF43B57629951EAF0026DCE3 /* MoimManagementController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF43B57529951EAF0026DCE3 /* MoimManagementController.swift */; };
 		BF43B57829951F0C0026DCE3 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF43B57729951F0C0026DCE3 /* ProfileView.swift */; };
 		BF6EC77F298D1B2E00F4B170 /* AttendanceResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF6EC77E298D1B2E00F4B170 /* AttendanceResultCell.swift */; };
 		BF9988FC298AD04E005723C7 /* PersonalInformationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9988FB298AD04E005723C7 /* PersonalInformationController.swift */; };
@@ -51,7 +51,7 @@
 		BF04086C2987E38C00F1129B /* RegistrationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationController.swift; sourceTree = "<group>"; };
 		BF04086E2987E70200F1129B /* CheckSecurityCodeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckSecurityCodeController.swift; sourceTree = "<group>"; };
 		BF4310F9298C525900270DBF /* AttendanceHistoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttendanceHistoryCell.swift; sourceTree = "<group>"; };
-		BF43B57529951EAF0026DCE3 /* MoimManageController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoimManageController.swift; sourceTree = "<group>"; };
+		BF43B57529951EAF0026DCE3 /* MoimManagementController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoimManagementController.swift; sourceTree = "<group>"; };
 		BF43B57729951F0C0026DCE3 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		BF6EC77E298D1B2E00F4B170 /* AttendanceResultCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttendanceResultCell.swift; sourceTree = "<group>"; };
 		BF9988FB298AD04E005723C7 /* PersonalInformationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalInformationController.swift; sourceTree = "<group>"; };
@@ -110,7 +110,7 @@
 		BF43B57429951CB90026DCE3 /* Management */ = {
 			isa = PBXGroup;
 			children = (
-				BF43B57529951EAF0026DCE3 /* MoimManageController.swift */,
+				BF43B57529951EAF0026DCE3 /* MoimManagementController.swift */,
 			);
 			path = Management;
 			sourceTree = "<group>";
@@ -310,7 +310,7 @@
 				E820792D298A137700B36FC9 /* MainSessionTimeCell.swift in Sources */,
 				E820792B298A119900B36FC9 /* MainSessionDetailCell.swift in Sources */,
 				E8207936298A248200B36FC9 /* MainSessionNoInfoCell.swift in Sources */,
-				BF43B57629951EAF0026DCE3 /* MoimManageController.swift in Sources */,
+				BF43B57629951EAF0026DCE3 /* MoimManagementController.swift in Sources */,
 				3AA713D1298946FF006F922F /* UIColor+Extension.swift in Sources */,
 				3AA713C929884007006F922F /* MainAttendanceDoneCell.swift in Sources */,
 				E820792F298A138500B36FC9 /* MainSessionAbsentCell.swift in Sources */,

--- a/momoIOS.xcodeproj/project.pbxproj
+++ b/momoIOS.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		BF04086D2987E38C00F1129B /* RegistrationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086C2987E38C00F1129B /* RegistrationController.swift */; };
 		BF04086F2987E70200F1129B /* CheckSecurityCodeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086E2987E70200F1129B /* CheckSecurityCodeController.swift */; };
 		BF4310FA298C525900270DBF /* AttendanceHistoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4310F9298C525900270DBF /* AttendanceHistoryCell.swift */; };
+		BF43B57629951EAF0026DCE3 /* MoimManageController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF43B57529951EAF0026DCE3 /* MoimManageController.swift */; };
+		BF43B57829951F0C0026DCE3 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF43B57729951F0C0026DCE3 /* ProfileView.swift */; };
 		BF6EC77F298D1B2E00F4B170 /* AttendanceResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF6EC77E298D1B2E00F4B170 /* AttendanceResultCell.swift */; };
 		BF9988FC298AD04E005723C7 /* PersonalInformationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9988FB298AD04E005723C7 /* PersonalInformationController.swift */; };
 		BF998900298BB0D3005723C7 /* InputMemberInfoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9988FF298BB0D3005723C7 /* InputMemberInfoController.swift */; };
@@ -49,6 +51,8 @@
 		BF04086C2987E38C00F1129B /* RegistrationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationController.swift; sourceTree = "<group>"; };
 		BF04086E2987E70200F1129B /* CheckSecurityCodeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckSecurityCodeController.swift; sourceTree = "<group>"; };
 		BF4310F9298C525900270DBF /* AttendanceHistoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttendanceHistoryCell.swift; sourceTree = "<group>"; };
+		BF43B57529951EAF0026DCE3 /* MoimManageController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoimManageController.swift; sourceTree = "<group>"; };
+		BF43B57729951F0C0026DCE3 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		BF6EC77E298D1B2E00F4B170 /* AttendanceResultCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttendanceResultCell.swift; sourceTree = "<group>"; };
 		BF9988FB298AD04E005723C7 /* PersonalInformationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalInformationController.swift; sourceTree = "<group>"; };
 		BF9988FF298BB0D3005723C7 /* InputMemberInfoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputMemberInfoController.swift; sourceTree = "<group>"; };
@@ -101,6 +105,14 @@
 				BF04086E2987E70200F1129B /* CheckSecurityCodeController.swift */,
 			);
 			path = Controller;
+			sourceTree = "<group>";
+		};
+		BF43B57429951CB90026DCE3 /* Management */ = {
+			isa = PBXGroup;
+			children = (
+				BF43B57529951EAF0026DCE3 /* MoimManageController.swift */,
+			);
+			path = Management;
 			sourceTree = "<group>";
 		};
 		BF9988FA298AD002005723C7 /* PersonalInformation */ = {
@@ -156,7 +168,9 @@
 		E8D5C3EF2984FC23003D1AD0 /* momoIOS */ = {
 			isa = PBXGroup;
 			children = (
+				BF43B57429951CB90026DCE3 /* Management */,
 				BF0408602987B3AA00F1129B /* Authentication */,
+				BF43B57729951F0C0026DCE3 /* ProfileView.swift */,
 				E8D5C3F02984FC23003D1AD0 /* AppDelegate.swift */,
 				E8D5C3F22984FC23003D1AD0 /* SceneDelegate.swift */,
 				E8D5C3F42984FC23003D1AD0 /* ViewController.swift */,
@@ -289,12 +303,14 @@
 				BF6EC77F298D1B2E00F4B170 /* AttendanceResultCell.swift in Sources */,
 				BF04086B2987E34800F1129B /* AuthCommonConstants.swift in Sources */,
 				3A5AC31029898B330080323A /* UIButton+Extension.swift in Sources */,
+				BF43B57829951F0C0026DCE3 /* ProfileView.swift in Sources */,
 				E8207934298A22D000B36FC9 /* MainSessionInfoCell.swift in Sources */,
 				E8207932298A163400B36FC9 /* UIView+Extension.swift in Sources */,
 				BFB8431F298CFF9200BA11EC /* UIStackView+Extension.swift in Sources */,
 				E820792D298A137700B36FC9 /* MainSessionTimeCell.swift in Sources */,
 				E820792B298A119900B36FC9 /* MainSessionDetailCell.swift in Sources */,
 				E8207936298A248200B36FC9 /* MainSessionNoInfoCell.swift in Sources */,
+				BF43B57629951EAF0026DCE3 /* MoimManageController.swift in Sources */,
 				3AA713D1298946FF006F922F /* UIColor+Extension.swift in Sources */,
 				3AA713C929884007006F922F /* MainAttendanceDoneCell.swift in Sources */,
 				E820792F298A138500B36FC9 /* MainSessionAbsentCell.swift in Sources */,

--- a/momoIOS/Management/MoimManageController.swift
+++ b/momoIOS/Management/MoimManageController.swift
@@ -1,8 +1,0 @@
-//
-//  MoimManageController.swift
-//  momoIOS
-//
-//  Created by 문다 on 2023/02/09.
-//
-
-import Foundation

--- a/momoIOS/Management/MoimManageController.swift
+++ b/momoIOS/Management/MoimManageController.swift
@@ -1,0 +1,8 @@
+//
+//  MoimManageController.swift
+//  momoIOS
+//
+//  Created by 문다 on 2023/02/09.
+//
+
+import Foundation

--- a/momoIOS/Management/MoimManagementController.swift
+++ b/momoIOS/Management/MoimManagementController.swift
@@ -1,0 +1,22 @@
+//
+//  MoimManageController.swift
+//  momoIOS
+//
+//  Created by 문다 on 2023/02/09.
+//
+
+import UIKit
+import SnapKit
+
+class MoimManagementcontrolelr: UIViewController {
+    
+    // MARK: - Properties
+    
+    private let profileView = ProfileView()
+    
+    // MARK: - Lifecycles
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/momoIOS/Management/MoimManagementController.swift
+++ b/momoIOS/Management/MoimManagementController.swift
@@ -1,5 +1,5 @@
 //
-//  MoimManageController.swift
+//  MoimManagementController.swift
 //  momoIOS
 //
 //  Created by 문다 on 2023/02/09.
@@ -13,10 +13,114 @@ class MoimManagementcontrolelr: UIViewController {
     // MARK: - Properties
     
     private let profileView = ProfileView()
+    private let moimSettingTableView = UITableView()
+    
+    private lazy var toEndThisMoimLabel: UILabel = {
+        let label = UILabel()
+        label.text = "현재 기수를 종료할까요?"
+        label.font = .systemFont(ofSize: 21, weight: .regular)
+        label.textColor = .rgba(37, 41, 48, 1)
+        return label
+    }()
+    
+    private lazy var toEndThisMoimButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("종료하기", size: 16, weight: .semibold, color: .rgba(37, 41, 45, 1))
+        button.titleLabel?.textAlignment = .center
+        button.backgroundColor = .white
+        button.layer.masksToBounds = true
+        button.layer.cornerRadius = 7
+        button.layer.borderColor = UIColor.rgba(201, 201, 201, 1).cgColor
+        button.layer.borderWidth = 1
+        return button
+    }()
     
     // MARK: - Lifecycles
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.view.backgroundColor = .rgba(245, 245, 245, 1)
+        setupCustomNav()
+        self.setupLayout()
+    }
+    
+    // MARK: - Helpers
+    
+    private func setupCustomNav() { // TODO: 나중에 루트뷰 설정하고 삭제해야하는 코드
+        // custom nav
+        let navBar = self.navigationController?.navigationBar
+        let appearance = UINavigationBarAppearance()
+        appearance.shadowColor = .rgba(24, 24, 24, 0.16)
+        appearance.backgroundColor = .rgba(245, 245, 245, 1)
+        navBar?.scrollEdgeAppearance = appearance
+        
+        // back button (left)
+        let title = UILabel()
+        title.text = "넥스터즈"
+        title.textColor = .rgba(56, 56, 56, 1)
+        title.font = .systemFont(ofSize: 21, weight: .bold)
+        self.navigationItem.hidesBackButton = true
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: title)
+    }
+    
+    private func setupSettingTableView() {
+        self.moimSettingTableView.delegate = self
+        self.moimSettingTableView.dataSource = self
+        self.moimSettingTableView.register(MoimSettingCell.self, forCellReuseIdentifier: MoimSettingCell.id)
+        view.addSubview(moimSettingTableView)
+        moimSettingTableView.showsVerticalScrollIndicator = false
+        moimSettingTableView.isScrollEnabled = false
+        moimSettingTableView.layer.cornerRadius = 10
+        moimSettingTableView.layer.borderColor = UIColor.clear.cgColor
+        moimSettingTableView.layer.borderWidth = 1
+        moimSettingTableView.layer.masksToBounds = true
+    }
+    
+    private func setupViews() {
+        view.addSubviews(profileView, toEndThisMoimLabel, toEndThisMoimButton)
+        setupSettingTableView()
+    }
+    
+    private func setupLayout() {
+        setupViews()
+        
+        profileView.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(10)
+            make.centerX.equalToSuperview()
+            make.height.equalTo(200)
+        }
+        
+        moimSettingTableView.snp.makeConstraints { make in
+            make.horizontalEdges.equalToSuperview().inset(20)
+            make.top.equalTo(profileView.snp.bottom).offset(40)
+            make.height.equalTo(100)
+        }
+        
+        toEndThisMoimLabel.snp.makeConstraints { make in
+            make.bottom.equalToSuperview().inset(120)
+            make.horizontalEdges.equalToSuperview().inset(20)
+        }
+        
+        toEndThisMoimButton.snp.makeConstraints { make in
+            make.bottom.equalToSuperview().inset(53)
+            make.horizontalEdges.equalToSuperview().inset(20)
+            make.height.equalTo(52)
+        }
+    }
+}
+
+extension MoimManagementcontrolelr: UITableViewDelegate, UITableViewDataSource {
+    func numberOfSections(in tableView: UITableView) -> Int {
+           return 1
+       }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 2
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: MoimSettingCell.id) as! MoimSettingCell
+        cell.settingTitle.text = indexPath.row == 0 ? "로그아웃" : "가입보안코드 확인"
+        return cell
     }
 }

--- a/momoIOS/Management/MoimSettingCell.swift
+++ b/momoIOS/Management/MoimSettingCell.swift
@@ -1,0 +1,69 @@
+//
+//  MoimSettingCell.swift
+//  momoIOS
+//
+//  Created by 문다 on 2023/02/09.
+//
+
+import UIKit
+import SnapKit
+
+class MoimSettingCell: UITableViewCell {
+    
+    // MARK: - Properties
+    
+    static let id = "MoimSettingCell"
+    
+    lazy var settingTitle: UILabel = {
+        let label = UILabel()
+        label.text = "설정"
+        label.font = .systemFont(ofSize: 16)
+        label.textColor = .rgba(56, 56, 56, 1)
+        return label
+    }()
+    
+    private let arrow: UIImageView = {
+        let imageView = UIImageView()
+        let imageConfig = UIImage.SymbolConfiguration(pointSize: 13, weight: .bold)
+        let image = UIImage(systemName: "arrow.right", withConfiguration: imageConfig)
+        imageView.image = image
+        imageView.tintColor = .rgba(159, 159, 159, 1)
+        return imageView
+    }()
+    
+    // MARK: - Initializer
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: MoimSettingCell.id)
+        self.setupCell()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.setupCell()
+    }
+    
+    // MARK: - Helpers
+    
+    private func setupCell() {
+        contentView.backgroundColor = .white
+        contentView.addSubviews(settingTitle, arrow)
+        
+        contentView.snp.makeConstraints { make in
+            make.horizontalEdges.equalToSuperview()
+            make.height.greaterThanOrEqualTo(50)
+        }
+        
+        settingTitle.snp.makeConstraints { make in
+            make.centerY.equalTo(contentView)
+            make.left.equalTo(contentView).offset(20)
+            make.height.equalTo(contentView)
+        }
+        
+        arrow.snp.makeConstraints { make in
+            make.centerY.equalTo(contentView)
+            make.right.equalTo(contentView).inset(20)
+//            make.height.equalTo(contentView)
+        }
+    }
+}

--- a/momoIOS/ProfileView.swift
+++ b/momoIOS/ProfileView.swift
@@ -64,7 +64,7 @@ class ProfileView: UIView {
             make.verticalEdges.equalTo(jobLabelView).inset(5)
             make.horizontalEdges.equalTo(jobLabelView).inset(10)
         }
-        jobLabelView.backgroundColor = UIColor.rgba(243, 243, 243, 1)
+        jobLabelView.backgroundColor = UIColor.rgba(210, 210, 210, 1)
         
         return view
     }()

--- a/momoIOS/ProfileView.swift
+++ b/momoIOS/ProfileView.swift
@@ -12,13 +12,13 @@ class ProfileView: UIView {
     
     // MARK: - Properties
     private let username = "김넥터"
-    private let userJob = "designer"
+    private let userJob = "admin"
     private let userYear = 22
     private let email = "nexters@naver.com"
     
     private lazy var profileImageView: UIImageView = {
         let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: 93, height: 93))
-        imageView.image = UIImage(named: "\(userJob)")!
+        imageView.image = UIImage(named: "\(userJob)") ?? UIImage(named: "designer")
         imageView.contentMode = .scaleAspectFill
         imageView.layer.cornerRadius = 93 / 2
         imageView.clipsToBounds = true

--- a/momoIOS/ProfileView.swift
+++ b/momoIOS/ProfileView.swift
@@ -1,0 +1,117 @@
+//
+//  ProfileView.swift
+//  momoIOS
+//
+//  Created by 문다 on 2023/02/09.
+//
+
+import UIKit
+import SnapKit
+
+class ProfileView: UIView {
+    
+    // MARK: - Properties
+    private let username = "김넥터"
+    private let userJob = "designer"
+    private let userYear = 22
+    private let email = "nexters@naver.com"
+    
+    private lazy var profileImageView: UIImageView = {
+        let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: 93, height: 93))
+        imageView.image = UIImage(named: "\(userJob)")!
+        imageView.contentMode = .scaleAspectFill
+        imageView.layer.cornerRadius = 93 / 2
+        imageView.clipsToBounds = true
+        imageView.layer.borderWidth = 1
+        imageView.layer.borderColor = UIColor.rgba(208, 208, 208, 1).cgColor
+        
+        return imageView
+    }()
+    
+    private lazy var userActiveStatus: UIView = {
+        let statusView = UIView()
+        
+        let status = UILabel()
+        status.text = "\(userYear)기 참여중"
+        status.font = .systemFont(ofSize: 13, weight: .bold)
+        status.textColor = .white
+        
+        statusView.addSubview(status)
+        status.snp.makeConstraints { make in
+            make.edges.equalTo(statusView).inset(9)
+        }
+        statusView.backgroundColor = UIColor.rgba(116, 207, 130, 1)
+        statusView.layer.cornerRadius = 5
+        return statusView
+    }()
+    
+    private lazy var userBasicInfomationView: UIStackView = {
+        let usernameLabel = UILabel()
+        let jobLabel = UILabel()
+        let jobLabelView = UIView()
+        let view = UIStackView(arrangedSubviews: [usernameLabel, jobLabelView])
+        view.axis = .horizontal
+        view.spacing = 10
+        
+        usernameLabel.text = username
+        usernameLabel.font = .systemFont(ofSize: 22, weight: .medium)
+        usernameLabel.textColor = .black
+        
+        jobLabel.text = userJob.uppercased()
+        jobLabel.font = .systemFont(ofSize: 13)
+        jobLabelView.addSubview(jobLabel)
+        jobLabel.snp.makeConstraints { make in
+            make.verticalEdges.equalTo(jobLabelView).inset(5)
+            make.horizontalEdges.equalTo(jobLabelView).inset(10)
+        }
+        jobLabelView.backgroundColor = UIColor.rgba(243, 243, 243, 1)
+        
+        return view
+    }()
+    
+    private lazy var userAdditionalInformationView: UILabel = {
+        let label = UILabel()
+        label.text = email
+        label.font = .systemFont(ofSize: 16)
+        label.textColor = UIColor.rgba(118, 118, 118, 1)
+        return label
+    }()
+    
+    // MARK: - Lifecycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.backgroundColor = .white
+        self.setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        
+        self.backgroundColor = .white
+        self.setupLayout()
+    }
+    // MARK: - Helpers
+    private func setupLayout() {
+        self.addSubviews(profileImageView, userActiveStatus, userBasicInfomationView, userAdditionalInformationView)
+        
+        profileImageView.snp.makeConstraints { make in
+            make.top.equalTo(self.snp.top).offset(36)
+            make.centerX.equalTo(self)
+        }
+        userActiveStatus.snp.makeConstraints { make in
+            make.top.equalTo(profileImageView.snp.centerY).offset(10)
+            make.left.equalTo(profileImageView.snp.centerX).offset(10)
+        }
+        
+        userBasicInfomationView.snp.makeConstraints { make in
+            make.top.equalTo(profileImageView.snp.bottom).offset(20)
+            make.centerX.equalTo(self)
+        }
+        userAdditionalInformationView.snp.makeConstraints { make in
+            make.top.equalTo(userBasicInfomationView.snp.bottom).offset(10)
+            make.centerX.equalTo(self)
+        }
+    }
+}

--- a/momoIOS/ViewController.swift
+++ b/momoIOS/ViewController.swift
@@ -47,6 +47,6 @@ class ViewController: UIViewController {
     }
     
     @objc private func goToOtherViewController() {
-        self.navigationController?.pushViewController(RegistrationController(), animated: true)
+        self.navigationController?.pushViewController(MoimManagementcontrolelr(), animated: true)
     }
 }


### PR DESCRIPTION
close #34

## Description
어드민 프로필 정보 조회 및 모임 설정 관리 화면을 구현했습니다 ~~!!
프로필 정보 조회 뷰는 유저의 프로필 조회 뷰와 동일해서 ProfileView: UIView로 빼주었습니다
_비밀번호 변경은 1차 MVP에서 제외, 개발 완료 후 넥스터즈 확정 이후로 연기_

## TODO
- [ ] 모달은 모달 공통화 진행 후 추가
- [ ] tab bar 생성 후 화면 전환 로직

<img width="250" alt="스크린샷 2023-02-09 오후 11 54 17" src="https://user-images.githubusercontent.com/57654681/218231786-37b8c4b7-1105-47e3-b036-0b9f422953bf.png">
