### PR TITLE
[FEAT][#43] 어드민 > 회원관리 > 회원개별등록 View 구현

### DIFF
--- a/momoIOS.xcodeproj/project.pbxproj
+++ b/momoIOS.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		BF04086B2987E34800F1129B /* AuthCommonConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086A2987E34800F1129B /* AuthCommonConstants.swift */; };
 		BF04086D2987E38C00F1129B /* RegistrationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086C2987E38C00F1129B /* RegistrationController.swift */; };
 		BF04086F2987E70200F1129B /* CheckSecurityCodeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086E2987E70200F1129B /* CheckSecurityCodeController.swift */; };
+		BF405C7829972C4900B5889D /* AddIndividualMemberViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF405C7729972C4900B5889D /* AddIndividualMemberViewController.swift */; };
 		BF4310FA298C525900270DBF /* AttendanceHistoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4310F9298C525900270DBF /* AttendanceHistoryCell.swift */; };
 		BF6EC77F298D1B2E00F4B170 /* AttendanceResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF6EC77E298D1B2E00F4B170 /* AttendanceResultCell.swift */; };
 		BF9988FC298AD04E005723C7 /* PersonalInformationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9988FB298AD04E005723C7 /* PersonalInformationController.swift */; };
@@ -48,6 +49,7 @@
 		BF04086A2987E34800F1129B /* AuthCommonConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCommonConstants.swift; sourceTree = "<group>"; };
 		BF04086C2987E38C00F1129B /* RegistrationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationController.swift; sourceTree = "<group>"; };
 		BF04086E2987E70200F1129B /* CheckSecurityCodeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckSecurityCodeController.swift; sourceTree = "<group>"; };
+		BF405C7729972C4900B5889D /* AddIndividualMemberViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddIndividualMemberViewController.swift; sourceTree = "<group>"; };
 		BF4310F9298C525900270DBF /* AttendanceHistoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttendanceHistoryCell.swift; sourceTree = "<group>"; };
 		BF6EC77E298D1B2E00F4B170 /* AttendanceResultCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttendanceResultCell.swift; sourceTree = "<group>"; };
 		BF9988FB298AD04E005723C7 /* PersonalInformationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalInformationController.swift; sourceTree = "<group>"; };
@@ -103,6 +105,14 @@
 			path = Controller;
 			sourceTree = "<group>";
 		};
+		BF405C7629972C0700B5889D /* MemberManagement */ = {
+			isa = PBXGroup;
+			children = (
+				BF405C7729972C4900B5889D /* AddIndividualMemberViewController.swift */,
+			);
+			path = MemberManagement;
+			sourceTree = "<group>";
+		};
 		BF9988FA298AD002005723C7 /* PersonalInformation */ = {
 			isa = PBXGroup;
 			children = (
@@ -156,6 +166,7 @@
 		E8D5C3EF2984FC23003D1AD0 /* momoIOS */ = {
 			isa = PBXGroup;
 			children = (
+				BF405C7629972C0700B5889D /* MemberManagement */,
 				BF0408602987B3AA00F1129B /* Authentication */,
 				E8D5C3F02984FC23003D1AD0 /* AppDelegate.swift */,
 				E8D5C3F22984FC23003D1AD0 /* SceneDelegate.swift */,
@@ -278,6 +289,7 @@
 				BF9988FC298AD04E005723C7 /* PersonalInformationController.swift in Sources */,
 				BF04086D2987E38C00F1129B /* RegistrationController.swift in Sources */,
 				E8D5C3F52984FC23003D1AD0 /* ViewController.swift in Sources */,
+				BF405C7829972C4900B5889D /* AddIndividualMemberViewController.swift in Sources */,
 				E8D5C3F12984FC23003D1AD0 /* AppDelegate.swift in Sources */,
 				BF04086F2987E70200F1129B /* CheckSecurityCodeController.swift in Sources */,
 				E8D5C3F32984FC23003D1AD0 /* SceneDelegate.swift in Sources */,

--- a/momoIOS/MemberManagement/AddIndividualMemberViewController.swift
+++ b/momoIOS/MemberManagement/AddIndividualMemberViewController.swift
@@ -34,6 +34,10 @@ class AddIndividualMemberViewcontroller: UIViewController {
         self.setupLayout()
     }
     
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+            self.view.endEditing(true)
+    }
+    
     // MARK: - Helpers
     
     private func setupCustomNav() {

--- a/momoIOS/MemberManagement/AddIndividualMemberViewController.swift
+++ b/momoIOS/MemberManagement/AddIndividualMemberViewController.swift
@@ -1,0 +1,87 @@
+//
+//  AddIndividualMemberViewController.swift
+//  momoIOS
+//
+//  Created by 문다 on 2023/02/11.
+//
+
+import UIKit
+import SnapKit
+
+class AddIndividualMemberViewcontroller: UIViewController {
+    
+    // MARK: - Properties
+    
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "회원정보를\n입력하세요."
+        label.numberOfLines = 0
+        label.font = .systemFont(ofSize: 40, weight: .regular)
+        label.textColor = .black
+        return label
+    }()
+    
+    private lazy var nameTextField = inputContainerView(placeholder: "이름")
+    private lazy var emailTextField = inputContainerView(placeholder: "메일 주소")
+    private lazy var addButton = actionButton(title: "등록하기")
+    
+    // MARK: - Lifecycles
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = .white
+        self.setupCustomNav()
+        self.setupLayout()
+    }
+    
+    // MARK: - Helpers
+    
+    private func setupCustomNav() {
+        // custom nav
+        let navBar = self.navigationController?.navigationBar
+        let appearance = UINavigationBarAppearance()
+        appearance.shadowColor = .rgba(24, 24, 24, 0.16)
+        appearance.backgroundColor = .white
+        navBar?.scrollEdgeAppearance = appearance
+        navBar?.tintColor = .black
+        
+        // back button (left)
+        self.navigationItem.hidesBackButton = true
+        navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "arrow.left"), style: .plain, target: self, action: nil)
+        
+        // title (center)
+        let title = UILabel()
+        title.text = "회원등록"
+        title.textColor = .black
+        title.font = .systemFont(ofSize: 15, weight: .semibold)
+        navigationItem.titleView = title
+    }
+    
+    private func setupViews() {
+        self.view.addSubviews(titleLabel, nameTextField, emailTextField, addButton)
+    }
+    
+    private func setupLayout() {
+        self.setupViews()
+        
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalTo(self.view.safeAreaLayoutGuide).offset(70)
+            make.left.right.equalTo(view).offset(20)
+        }
+        
+        nameTextField.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(55)
+            make.left.right.equalToSuperview().inset(20)
+        }
+        
+        emailTextField.snp.makeConstraints { make in
+            make.top.equalTo(nameTextField.snp.bottom).offset(10)
+            make.left.right.equalToSuperview().inset(20)
+        }
+        
+        addButton.snp.makeConstraints { make in
+            make.top.equalTo(emailTextField.snp.bottom).offset(30)
+            make.left.right.equalToSuperview().inset(20)
+        }
+    }
+}


### PR DESCRIPTION
close #43

## Description
운영진이 엑셀을 통해 한 번에 회원을 등록하는 것이 아닌,
개별 회원을 등록하는 화면을 구현했습니다 😽

## TODO
- [ ] DB에 등록되지 않은 회원을 등록하려는 경우의 예외처리: 토스트 메시지 추가
- [ ] 화면 전환 로직

<img width="250" alt="스크린샷 2023-02-11 오전 11 30 27" src="https://user-images.githubusercontent.com/57654681/218234477-43b7784d-f74e-4c36-9fd4-89d7ca6a7c71.png">
