### PR TITLE
[STYLE][#49] 재사용되는 컴포넌트 분리

### DIFF
--- a/momoIOS.xcodeproj/project.pbxproj
+++ b/momoIOS.xcodeproj/project.pbxproj
@@ -26,6 +26,9 @@
 		BF04086D2987E38C00F1129B /* RegistrationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086C2987E38C00F1129B /* RegistrationController.swift */; };
 		BF04086F2987E70200F1129B /* CheckSecurityCodeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF04086E2987E70200F1129B /* CheckSecurityCodeController.swift */; };
 		BF405C7829972C4900B5889D /* AddIndividualMemberViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF405C7729972C4900B5889D /* AddIndividualMemberViewController.swift */; };
+		BF405C7E29976DB400B5889D /* CommonTitleLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF405C7D29976DB400B5889D /* CommonTitleLabel.swift */; };
+		BF405C8029976F9300B5889D /* CommonTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF405C7F29976F9300B5889D /* CommonTextField.swift */; };
+		BF405C82299773AA00B5889D /* CommonActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF405C81299773AA00B5889D /* CommonActionButton.swift */; };
 		BF4310FA298C525900270DBF /* AttendanceHistoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4310F9298C525900270DBF /* AttendanceHistoryCell.swift */; };
 		BF43B57629951EAF0026DCE3 /* MoimManagementController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF43B57529951EAF0026DCE3 /* MoimManagementController.swift */; };
 		BF43B57829951F0C0026DCE3 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF43B57729951F0C0026DCE3 /* ProfileView.swift */; };
@@ -71,6 +74,9 @@
 		BF04086C2987E38C00F1129B /* RegistrationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationController.swift; sourceTree = "<group>"; };
 		BF04086E2987E70200F1129B /* CheckSecurityCodeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckSecurityCodeController.swift; sourceTree = "<group>"; };
 		BF405C7729972C4900B5889D /* AddIndividualMemberViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddIndividualMemberViewController.swift; sourceTree = "<group>"; };
+		BF405C7D29976DB400B5889D /* CommonTitleLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonTitleLabel.swift; sourceTree = "<group>"; };
+		BF405C7F29976F9300B5889D /* CommonTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonTextField.swift; sourceTree = "<group>"; };
+		BF405C81299773AA00B5889D /* CommonActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonActionButton.swift; sourceTree = "<group>"; };
 		BF4310F9298C525900270DBF /* AttendanceHistoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttendanceHistoryCell.swift; sourceTree = "<group>"; };
 		BF43B57529951EAF0026DCE3 /* MoimManagementController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoimManagementController.swift; sourceTree = "<group>"; };
 		BF43B57729951F0C0026DCE3 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
@@ -129,7 +135,10 @@
 		3ABBF742299750A4004D4D0B /* UI */ = {
 			isa = PBXGroup;
 			children = (
-				3A8E2DE029976A8F00D5476A /* AbsenceModalViewController.swift */,
+				3A5AC3092989784A0080323A /* AbsenceModalViewController.swift */,
+				BF405C7D29976DB400B5889D /* CommonTitleLabel.swift */,
+				BF405C7F29976F9300B5889D /* CommonTextField.swift */,
+				BF405C81299773AA00B5889D /* CommonActionButton.swift */,
 				BF43B57729951F0C0026DCE3 /* ProfileView.swift */,
 			);
 			path = UI;
@@ -399,10 +408,12 @@
 				BF998900298BB0D3005723C7 /* InputMemberInfoController.swift in Sources */,
 				BF0408632987B3AA00F1129B /* LoginController.swift in Sources */,
 				BF6EC77F298D1B2E00F4B170 /* AttendanceResultCell.swift in Sources */,
+				BF405C7E29976DB400B5889D /* CommonTitleLabel.swift in Sources */,
 				BF04086B2987E34800F1129B /* AuthCommonConstants.swift in Sources */,
 				3A5AC31029898B330080323A /* UIButton+Extension.swift in Sources */,
 				BF43B57829951F0C0026DCE3 /* ProfileView.swift in Sources */,
 				3A8E2DDF2997697E00D5476A /* AttendanceCodeDetailViewController.swift in Sources */,
+				BF405C82299773AA00B5889D /* CommonActionButton.swift in Sources */,
 				E8207934298A22D000B36FC9 /* MainSessionInfoCell.swift in Sources */,
 				3A8E2DE129976A8F00D5476A /* AbsenceModalViewController.swift in Sources */,
 				3ABBF74829975801004D4D0B /* NotActiveSessionCell.swift in Sources */,
@@ -417,6 +428,7 @@
 				3ABEDB742997719000F9BF1C /* String+Extension.swift in Sources */,
 				3AA713D1298946FF006F922F /* UIColor+Extension.swift in Sources */,
 				3AA713C929884007006F922F /* MainAttendanceDoneCell.swift in Sources */,
+				BF405C8029976F9300B5889D /* CommonTextField.swift in Sources */,
 				BF43B57A29952AFF0026DCE3 /* MoimSettingCell.swift in Sources */,
 				E820792F298A138500B36FC9 /* MainSessionAbsentCell.swift in Sources */,
 				BF4310FA298C525900270DBF /* AttendanceHistoryCell.swift in Sources */,

--- a/momoIOS/AdminSide/MemberManagement/AddIndividualMemberViewController.swift
+++ b/momoIOS/AdminSide/MemberManagement/AddIndividualMemberViewController.swift
@@ -12,18 +12,10 @@ class AddIndividualMemberViewcontroller: UIViewController {
     
     // MARK: - Properties
     
-    private lazy var titleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "회원정보를\n입력하세요."
-        label.numberOfLines = 0
-        label.font = .systemFont(ofSize: 40, weight: .regular)
-        label.textColor = .black
-        return label
-    }()
-    
-    private lazy var nameTextField = inputContainerView(placeholder: "이름")
-    private lazy var emailTextField = inputContainerView(placeholder: "메일 주소")
-    private lazy var addButton = actionButton(title: "등록하기")
+    private lazy var titleLabel = CommonTitleLabel(labelText: "회원정보를\n입력하세요.")
+    private lazy var nameTextField = CommonTextField(placeholderText: "이름")
+    private lazy var emailTextField = CommonTextField(placeholderText: "메일 주소")
+    private lazy var addButton = CommonActionButton(buttonTitle: "등록하기")
     
     // MARK: - Lifecycles
     

--- a/momoIOS/Authentication/Controller/AuthCommonConstants.swift
+++ b/momoIOS/Authentication/Controller/AuthCommonConstants.swift
@@ -8,42 +8,9 @@
 import UIKit
 
 // MARK: - Colors
-let authDefaultButtonColor: UIColor = .rgba(56, 56, 56, 1)
-
-// MARK: - UILabel
-let welcomeTitle: UILabel = {
-    let title = UILabel()
-    title.text = "간단한 출석체크,\n모두모여에서"
-    title.font = UIFont.systemFont(ofSize: 40, weight: .regular)
-    title.numberOfLines = 0
-    return title
-}()
-
-// MARK: - UITextField
-func inputContainerView(placeholder: String, isSecureField: Bool = false) -> UITextField {
-    let textfield = UITextField()
-    textfield.heightAnchor.constraint(equalToConstant: 55).isActive = true
-    textfield.placeholder = placeholder
-    textfield.borderStyle = .roundedRect
-    textfield.font = UIFont.systemFont(ofSize: 16)
-    textfield.textColor = .black
-    textfield.attributedPlaceholder = NSAttributedString(string: placeholder, attributes: [NSAttributedString.Key.foregroundColor: UIColor.gray])
-    textfield.isSecureTextEntry = isSecureField
-    return textfield
-}
+let defaultButtonColor: UIColor = .rgba(56, 56, 56, 1)
 
 // MARK: - Buttons
-func actionButton(title: String) -> UIButton {
-    let button = UIButton(type: .system)
-    button.setTitle(title, for: .normal)
-    button.setTitleColor(UIColor.white, for: .normal)
-    button.backgroundColor = authDefaultButtonColor
-    button.heightAnchor.constraint(equalToConstant: 55).isActive = true
-    button.layer.cornerRadius = 8
-    button.titleLabel?.font = .boldSystemFont(ofSize: 18)
-    return button
-}
-
 func pushAnotherViewButton(subtitle: String, title: String) -> UIButton {
     let button = UIButton(type: .system)
     let attributedTitle = NSMutableAttributedString(

--- a/momoIOS/Authentication/Controller/CheckSecurityCodeController.swift
+++ b/momoIOS/Authentication/Controller/CheckSecurityCodeController.swift
@@ -8,14 +8,9 @@
 import UIKit
 
 class CheckSecurityCodeController: UIViewController {
+    
     // MARK: - Properties
-    private let guidePhrase: UILabel = {
-        let phrase = UILabel()
-        phrase.text = "보안코드를\n입력해주세요."
-        phrase.font = UIFont.systemFont(ofSize: 40, weight: .regular)
-        phrase.numberOfLines = 0
-        return phrase
-    }()
+    private lazy var guidePhrase = CommonTitleLabel(labelText: "보안코드를\n입력해주세요.")
     
     private let codeField: UITextField = {
         let field = UITextField()
@@ -30,9 +25,7 @@ class CheckSecurityCodeController: UIViewController {
         return border
     }()
 
-    private let completeButton: UIButton = {
-        return actionButton(title: "가입완료!")
-    }()
+    private let completeButton = CommonActionButton(buttonTitle: "가입완료!")
     
     // MARK: - Lifecyle
     override func viewDidLoad() {

--- a/momoIOS/Authentication/Controller/InputMemberInfoController.swift
+++ b/momoIOS/Authentication/Controller/InputMemberInfoController.swift
@@ -23,7 +23,7 @@ class InputMemberInfoController: UIViewController {
         let view = UIView()
         
         let label = setLabel(text: "이름")
-        let textField = inputContainerView(placeholder: "")
+        let textField = CommonTextField(placeholderText: "")
         
         view.addSubviews(label, textField)
         label.snp.makeConstraints { make in
@@ -41,7 +41,7 @@ class InputMemberInfoController: UIViewController {
         let view = UIView()
         
         let titleLabel = setLabel(text: "기수")
-        let textField = inputContainerView(placeholder: "")
+        let textField = CommonTextField(placeholderText: "")
         let yearLabel = setLabel(text: "기")
         
         view.addSubviews(titleLabel, textField, yearLabel)
@@ -106,9 +106,7 @@ class InputMemberInfoController: UIViewController {
         return button
     }
     
-    private let completeButton: UIButton = {
-        return actionButton(title: "가입완료!")
-    }()
+    private let completeButton = CommonActionButton(buttonTitle: "가입완료!")
     
     // MARK: - Lifecycles
     

--- a/momoIOS/Authentication/Controller/LoginController.swift
+++ b/momoIOS/Authentication/Controller/LoginController.swift
@@ -11,25 +11,11 @@ import SnapKit
 class LoginController: UIViewController {
     // MARK: - Properties
     
-    private let welcomeTitle: UILabel = {
-        let title = UILabel()
-        title.text = "간단한 출석체크,\n모두모여에서"
-        title.font = UIFont.systemFont(ofSize: 40, weight: .regular)
-        title.numberOfLines = 0
-        return title
-    }()
+    private lazy var welcomeTitle = CommonTitleLabel(labelText: "간단한 출석체크,\n모두모여에서")
+    private lazy var emailTextField = CommonTextField(placeholderText: "이메일을 입력해주세요")
+    private lazy var passwordTextField = CommonTextField(placeholderText: "비밀번호를 입력해주세요", isSecure: true)
     
-    private lazy var emailTextField: UITextField = {
-        return inputContainerView(placeholder: "이메일을 입력해주세요")
-    }()
-    
-    private lazy var passwordTextField: UITextField = {
-        return inputContainerView(placeholder: "비밀번호를 입력해주세요", isSecureField: true)
-    }()
-    
-    private let loginButton: UIButton = {
-        return actionButton(title: "로그인")
-    }()
+    private let loginButton = CommonActionButton(buttonTitle: "로그인")
     
     private let pushRegistrationViewButton: UIButton = {
         return pushAnotherViewButton(subtitle: "회원가입이 필요하다면?", title: "가입하기")

--- a/momoIOS/Authentication/Controller/RegistrationController.swift
+++ b/momoIOS/Authentication/Controller/RegistrationController.swift
@@ -11,9 +11,9 @@ import SnapKit
 class RegistrationController: UIViewController {
     // MARK: - Properties
     
-    private lazy var emailTextField: UITextField = {
-        return inputContainerView(placeholder: "이메일을 입력해주세요")
-    }()
+    private lazy var welcomeTitle = CommonTitleLabel(labelText: "간단한 출석체크,\n모두모여에서")
+    
+    private lazy var emailTextField = CommonTextField(placeholderText: "이메일을 입력해주세요")
     
     private let validEmailFormatLabel: UILabel = {
         let label = UILabel()
@@ -22,9 +22,7 @@ class RegistrationController: UIViewController {
         return label
     }()
     
-    private lazy var passwordTextField: UITextField = {
-        return inputContainerView(placeholder: "비밀번호를 입력해주세요", isSecureField: true)
-    }()
+    private lazy var passwordTextField = CommonTextField(placeholderText: "비밀번호를 입력해주세요", isSecure: true)
     
     private let validPasswordFormatLabel: UILabel = {
         let label = UILabel()
@@ -35,9 +33,7 @@ class RegistrationController: UIViewController {
         return label
     }()
     
-    private lazy var checkPasswordTextField: UITextField = {
-        return inputContainerView(placeholder: "비밀번호를 재입력해주세요", isSecureField: true)
-    }()
+    private lazy var checkPasswordTextField = CommonTextField(placeholderText: "비밀번호를 재입력해주세요", isSecure: true)
     
     private let confirmPasswordLabel: UILabel = {
         let label = UILabel()
@@ -47,9 +43,7 @@ class RegistrationController: UIViewController {
         return label
     }()
     
-    private let registrationButton: UIButton = {
-        return actionButton(title: "가입하기")
-    }()
+    private let registrationButton = CommonActionButton(buttonTitle: "가입하기")
     
     private let pushLoginViewButton: UIButton = {
         return pushAnotherViewButton(subtitle: "이미 가입했다면?", title: "로그인하기")

--- a/momoIOS/Common/UI/CommonActionButton.swift
+++ b/momoIOS/Common/UI/CommonActionButton.swift
@@ -1,0 +1,37 @@
+//
+//  CommonActionButton.swift
+//  momoIOS
+//
+//  Created by 문다 on 2023/02/11.
+//
+
+import UIKit
+
+class CommonActionButton: UIButton {
+    
+    // MARK: - Lifecycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.setupButton()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.setupButton()
+    }
+    
+    convenience init(buttonTitle: String) {
+        self.init(frame: .zero)
+        self.setTitle(buttonTitle, for: .normal)
+    }
+
+    // MARK: - Helpers
+    private func setupButton() {
+        self.setTitleColor(UIColor.white, for: .normal)
+        self.backgroundColor = defaultButtonColor
+        self.heightAnchor.constraint(equalToConstant: 55).isActive = true
+        self.layer.cornerRadius = 8
+        self.titleLabel?.font = .boldSystemFont(ofSize: 18)
+    }
+}

--- a/momoIOS/Common/UI/CommonTextField.swift
+++ b/momoIOS/Common/UI/CommonTextField.swift
@@ -1,0 +1,41 @@
+//
+//  CommonTextField.swift
+//  momoIOS
+//
+//  Created by 문다 on 2023/02/11.
+//
+
+import UIKit
+import SnapKit
+
+class CommonTextField: UITextField {
+    
+    // MARK: - Lifecycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.setupTextField()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.setupTextField()
+    }
+    
+    convenience init(placeholderText: String, isSecure: Bool = false) {
+        self.init(frame: .zero)
+        self.placeholder = placeholderText
+        self.attributedPlaceholder = NSAttributedString(string: placeholderText, attributes: [NSAttributedString.Key.foregroundColor: UIColor.gray])
+        self.isSecureTextEntry = isSecure
+    }
+
+    // MARK: - Helpers
+    private func setupTextField() {
+        self.snp.makeConstraints { make in
+            make.height.equalTo(55)
+        }
+        self.borderStyle = .roundedRect
+        self.font = UIFont.systemFont(ofSize: 16)
+        self.textColor = .black
+    }
+}

--- a/momoIOS/Common/UI/CommonTitleLabel.swift
+++ b/momoIOS/Common/UI/CommonTitleLabel.swift
@@ -1,0 +1,36 @@
+//
+//  CommonTitleLabel.swift
+//  momoIOS
+//
+//  Created by 문다 on 2023/02/11.
+//
+
+import UIKit
+
+class CommonTitleLabel: UILabel {
+    
+    // MARK: - Lifecycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.setupLabel()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.setupLabel()
+    }
+    
+    convenience init(labelText: String) {
+        self.init(frame: .zero)
+        self.text = "\(labelText)"
+    }
+    
+    // MARK: - Helpers
+    
+    private func setupLabel() {
+        self.numberOfLines = 0
+        self.font = .systemFont(ofSize: 40, weight: .regular)
+        self.textColor = .black
+    }
+}


### PR DESCRIPTION
## Description
- AuthCommonConstatns: 한 파일에 모두 담겨있던 코드를 조금 분리했어요
- 클래스들은 momoIOS/Common/UI 내에 Common~이라는 이름으로 되어있고, 사진으로 첨부했습니다 🤓
- 버튼은 다른 뷰에서도 똑같이 많이 쓰여서 필요하다면 참고해 주세용

## TODO 
- [ ] 일단 큰 것만 분리! 자잘한 것들은 나중에 필요하다면 수정하겠습니다

<img width="250" alt="스크린샷 2023-02-11 오후 3 53 33" src="https://user-images.githubusercontent.com/57654681/218245814-b32b68b9-2c8d-45ec-9f06-43684966191d.png">
