### PR TITLE
[FEAT] UIButton+Extension 커스텀 폰트 & Image 설정

### DIFF
--- a/momoIOS/Common/Extensions/UIButton+Extension.swift
+++ b/momoIOS/Common/Extensions/UIButton+Extension.swift
@@ -8,19 +8,24 @@
 import UIKit
 
 extension UIButton {
-    func setTitle(_ title: String, size: CGFloat, weight: UIFont.Weight, color: UIColor) {
+    func setTitle(_ title: String, font: UIFont, color: UIColor) {
         if #available(iOS 15.0, *) {
             var attributedTitle = AttributedString(title)
-            attributedTitle.font = .pretendard(size: size, weight: weight)
+            attributedTitle.font = font
             attributedTitle.foregroundColor = color
             var configuration = self.configuration ?? .plain()
             configuration.attributedTitle = attributedTitle
             self.configuration = configuration
         } else {
             self.setTitle(title, for: .normal)
-            self.titleLabel?.font = .pretendard(size: size, weight: weight)
+            self.titleLabel?.font = font
             self.setTitleColor(color, for: .normal)
         }
+    }
+    
+    func setTitle(_ title: String, size: CGFloat, weight: UIFont.Weight, color: UIColor) {
+        let font = UIFont.pretendard(size: size, weight: weight)
+        self.setTitle(title, font: font, color: color)
     }
     
     func configurate(

--- a/momoIOS/Common/Extensions/UIButton+Extension.swift
+++ b/momoIOS/Common/Extensions/UIButton+Extension.swift
@@ -11,14 +11,14 @@ extension UIButton {
     func setTitle(_ title: String, size: CGFloat, weight: UIFont.Weight, color: UIColor) {
         if #available(iOS 15.0, *) {
             var attributedTitle = AttributedString(title)
-            attributedTitle.font = .systemFont(ofSize: size, weight: weight)
+            attributedTitle.font = .pretendard(size: size, weight: weight)
             attributedTitle.foregroundColor = color
             var configuration = self.configuration ?? .plain()
             configuration.attributedTitle = attributedTitle
             self.configuration = configuration
         } else {
             self.setTitle(title, for: .normal)
-            self.titleLabel?.font = .systemFont(ofSize: size, weight: weight)
+            self.titleLabel?.font = .pretendard(size: size, weight: weight)
             self.setTitleColor(color, for: .normal)
         }
     }

--- a/momoIOS/Common/Extensions/UIButton+Extension.swift
+++ b/momoIOS/Common/Extensions/UIButton+Extension.swift
@@ -61,4 +61,28 @@ extension UIButton {
         let edgeInsets = padding.map { NSDirectionalEdgeInsets(top: $0, leading: $0, bottom: $0, trailing: $0) }
         self.configurate(bgColor: bgColor, strokeColor: strokeColor, strokeWidth: strokeWidth, cornerRadius: cornerRadius, edgeInsets: edgeInsets)
     }
+    
+    func setImage(_ image: UIImage?, tintColor: UIColor, padding: CGFloat, direction: NSDirectionalRectEdge) {
+        if #available(iOS 15.0, *) {
+            var configuration = self.configuration ?? .plain()
+            configuration.imagePadding = padding / 2
+            configuration.image = image
+            configuration.titlePadding = padding / 2
+            configuration.imagePlacement = direction
+            self.configuration = configuration
+            self.tintColor = tintColor
+        } else {
+            self.setImage(image, for: .normal)
+            self.tintColor = tintColor
+            if direction == .trailing {
+                self.semanticContentAttribute = .forceRightToLeft
+                self.imageEdgeInsets = UIEdgeInsets(top: 0, left: padding / 2, bottom: 0, right: 0)
+                self.contentEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: padding / 2)
+            } else if direction == .leading {
+                self.semanticContentAttribute = .forceLeftToRight
+                self.imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: padding / 2)
+                self.contentEdgeInsets = UIEdgeInsets(top: 0, left: padding / 2, bottom: 0, right: 0)
+            }
+        }
+    }
 }


### PR DESCRIPTION
UIButton+Extension 수정했습니당
버튼도 custom font 되도록 수정하고 이미지 설정했을 때 configuation이랑 동시에 edge 줄 수 있도록 메소드로 작성해놨습니당.
다음처럼 쓸 수 있어용

```
button.setImage(UIImage(systemName: "plus.circle.fill"), tintColor: .gray600, padding: 15, direction: .trailing)
```

direction이 leading이면 이미지가 텍스트보다 앞에 있고, trailing이면 이미지가 텍스트보다 뒤에 있습니당
padding은 이미지랑 텍스트 사이 inset 값입니당~

결과물
![Simulator Screen Shot - iPhone 14 Pro - 2023-02-25 at 15 09 08](https://user-images.githubusercontent.com/63590121/221341722-7d650711-32c8-47a1-b784-12da3e9e5be8.png)
