### PR TITLE
[FEAT] UIColor+Extension Stroke color 추가 & 커스텀 alert 구현

### DIFF
--- a/momoIOS/AdminSide/AdminSession/AddSessionViewController.swift
+++ b/momoIOS/AdminSide/AdminSession/AddSessionViewController.swift
@@ -168,13 +168,20 @@ class AddSessionViewController: UIViewController {
 // MARK: - event 처리 용 extension
 extension AddSessionViewController {
     @objc func didTapDeleteButton(_ sender: UIButton) {
-        // MARK: 삭제 로직 추가 및 custom alert vc
-        self.navigationController?.popViewController(animated: true)
+        let alert = CommonBottomAlert()
+        alert.configure(title: "세션을 삭제하시나요?", description: "삭제하신다면 세션 내용은 지워지며,\n다시 새로 등록하셔야 합니다.", cancelTitle: "취소", confirmTitle: "삭제", cancelCompletion: nil, confirmCompletion: { [weak self] in
+            // MARK: 삭제 로직 추가
+            self?.navigationController?.popViewController(animated: true)
+        })
+        alert.show()
     }
     
     @objc func didTapBackButton(_ sender: UIButton) {
-        // MARK: custom alert vc
-        self.navigationController?.popViewController(animated: true)
+        let alert = CommonBottomAlert()
+        alert.configure(title: "저장하지 않고 나가시나요?", description: "나가신다면 작성한 내용은 저장되지 않습니다.", cancelTitle: "취소", confirmTitle: "나가기", cancelCompletion: nil, confirmCompletion: { [weak self] in
+            self?.navigationController?.popViewController(animated: true)
+        })
+        alert.show()
     }
     
     @objc func didTapTimePickerBtn(_ sender: UIButton) {

--- a/momoIOS/Common/Extensions/UIColor+Extension.swift
+++ b/momoIOS/Common/Extensions/UIColor+Extension.swift
@@ -27,6 +27,8 @@ extension UIColor {
     // Key Color
     /// 0x946BEA
     static let main = UIColor(hex: 0x946BEA)
+    /// 0xF4EFFF
+    static let p100 = UIColor(hex: 0xF4EFFF)
     /// 0xFF6464
     static let warning = UIColor(hex: 0xFF6464)
     /// 0x7FCBE5
@@ -35,6 +37,8 @@ extension UIColor {
     static let attendanceLate = UIColor(hex: 0xFFC531)
     /// 0xFF8B32
     static let noticeAbsance = UIColor(hex: 0xFF8B32)
+    /// 0xD5CCEE
+    static let stroke = UIColor(hex: 0xD5CCEE)
     
     // Text Color
     /// 0x222222


### PR DESCRIPTION
AddSessionViewController에 custom Alert를 추가했습니당
UIColor extension에 stroke color도 추가했어용

<img width="300" alt="스크린샷 2023-02-26 오전 2 11 46" src="https://user-images.githubusercontent.com/63590121/221370315-b4bb50f0-8bb9-40d7-8abe-5a5d443d183e.png">

<img width="250" alt="스크린샷 2023-02-26 오전 2 12 03" src="https://user-images.githubusercontent.com/63590121/221370330-05eaaf95-7d9d-4069-b5ce-36495137b854.png"> <img width="250" alt="스크린샷 2023-02-26 오전 2 11 59" src="https://user-images.githubusercontent.com/63590121/221370333-762e60db-3b26-4d37-baa0-7da846c4f591.png">
