### PR TITLE
[FEAT][#86] 유저 개인프로필(히스토리) GUI 적용

### DIFF
--- a/momoIOS.xcodeproj/project.pbxproj
+++ b/momoIOS.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		BF43B57A29952AFF0026DCE3 /* MoimSettingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF43B57929952AFF0026DCE3 /* MoimSettingCell.swift */; };
 		BF9988FC298AD04E005723C7 /* PersonalInformationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9988FB298AD04E005723C7 /* PersonalInformationController.swift */; };
 		BF998900298BB0D3005723C7 /* InputMemberInfoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9988FF298BB0D3005723C7 /* InputMemberInfoController.swift */; };
+		BF9BC4C629AB996B006A8CB0 /* Attendance.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9BC4C529AB996B006A8CB0 /* Attendance.swift */; };
 		BFB8431F298CFF9200BA11EC /* UIStackView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB8431E298CFF9200BA11EC /* UIStackView+Extension.swift */; };
 		BFC2E406299E5B22001D1E34 /* momo++Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC2E405299E5B22001D1E34 /* momo++Bundle.swift */; };
 		BFF7EE1F29A9DF37002E292F /* JobButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF7EE1E29A9DF37002E292F /* JobButtonView.swift */; };
@@ -125,6 +126,7 @@
 		BF43B57929952AFF0026DCE3 /* MoimSettingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoimSettingCell.swift; sourceTree = "<group>"; };
 		BF9988FB298AD04E005723C7 /* PersonalInformationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalInformationController.swift; sourceTree = "<group>"; };
 		BF9988FF298BB0D3005723C7 /* InputMemberInfoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputMemberInfoController.swift; sourceTree = "<group>"; };
+		BF9BC4C529AB996B006A8CB0 /* Attendance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Attendance.swift; sourceTree = "<group>"; };
 		BFB8431E298CFF9200BA11EC /* UIStackView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+Extension.swift"; sourceTree = "<group>"; };
 		BFC2E405299E5B22001D1E34 /* momo++Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "momo++Bundle.swift"; sourceTree = "<group>"; };
 		BFF7EE1E29A9DF37002E292F /* JobButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobButtonView.swift; sourceTree = "<group>"; };
@@ -351,6 +353,7 @@
 				3A0B570D29AAA161002D6F93 /* AttendanceResultCell.swift */,
 				BF9988FB298AD04E005723C7 /* PersonalInformationController.swift */,
 				BF4310F9298C525900270DBF /* AttendanceHistoryCell.swift */,
+				BF9BC4C529AB996B006A8CB0 /* Attendance.swift */,
 			);
 			path = PersonalInformation;
 			sourceTree = "<group>";
@@ -601,6 +604,7 @@
 				3A8BDEF729AA8144005CF633 /* AttendanceStatusButton.swift in Sources */,
 				3A0B571429AACD3F002D6F93 /* AddIndividualMemberViewController.swift in Sources */,
 				BF405C8029976F9300B5889D /* CommonTextField.swift in Sources */,
+				BF9BC4C629AB996B006A8CB0 /* Attendance.swift in Sources */,
 				BF43B57A29952AFF0026DCE3 /* MoimSettingCell.swift in Sources */,
 				E820792F298A138500B36FC9 /* MainSessionAbsentCell.swift in Sources */,
 				3A8FC29D29A9F31D000B9315 /* MemberListViewController.swift in Sources */,

--- a/momoIOS/UserSide/PersonalInformation/Attendance.swift
+++ b/momoIOS/UserSide/PersonalInformation/Attendance.swift
@@ -1,0 +1,23 @@
+//
+//  Attendance.swift
+//  momoIOS
+//
+//  Created by 문다 on 2023/02/26.
+//
+
+import UIKit
+
+enum AttendanceType {
+    case present
+    case late
+    case AWOL // Absent without leave 무단결석
+    case AWL // Absent with leave 통보결석
+}
+
+struct Attendance {
+    let icon: String
+    let toString: String
+    let textColor: UIColor
+    let backgroundColor: UIColor
+    let score: Int
+}

--- a/momoIOS/UserSide/PersonalInformation/AttendanceHistoryCell.swift
+++ b/momoIOS/UserSide/PersonalInformation/AttendanceHistoryCell.swift
@@ -6,55 +6,49 @@
 //
 
 import UIKit
+import SnapKit
+
 
 class AttendanceHistoryCell: UITableViewCell {
-    
+
     // MARK: - Properties
     
     static let id = "AttendanceHistoryCell"
     
-    private lazy var historyDateContainerView = setupHistoryIndexView()
     private let attendanceStatusContainerView = UIView()
     
-    private let weekLabel: UILabel = {
+    var weekLabel: UILabel = {
         let label = UILabel()
-        label.text = "1주차"
-        label.font = .systemFont(ofSize: 14)
-        label.textColor = .black
+        label.text = "1주차 (1/7)"
+        label.font = .body14
+        label.textColor = .gray600
         return label
     }()
     
-    private let dateLabel: UILabel = {
-        let label = UILabel()
-        label.text = "(1/7)"
-        label.font = .systemFont(ofSize: 14)
-        label.textColor = .black
-        return label
+    var statusIcon: UILabel = {
+        let icon = UILabel()
+        icon.text = "🔵"
+        icon.font = .pretendard(size: 14, weight: .w500)
+        return icon
     }()
     
-    private let attendanceStatusLabel: UILabel = {
+    var attendanceStatusLabel: UILabel = {
         let label = UILabel()
         label.text = "정상 출석"
-        label.font = .systemFont(ofSize: 16, weight: .medium)
-        label.textColor = .rgba(84, 84, 84, 1)
+        label.font = .pretendard(size: 16, weight: .w600)
+        label.textColor = .gray700
         return label
     }()
     
-    private let attendedDatetime: UILabel = {
+    var attendedDatetime: UILabel = {
         let label = UILabel()
         label.text = "2023.01.07 12:00"
-        label.font = .systemFont(ofSize: 11)
-        label.textColor = .gray
+        label.font = .body14
+        label.textColor = .gray600
         return label
     }()
     
-    private let dailyAttendanceScore: UILabel = {
-        let label = UILabel()
-        label.text = "-"
-        label.font = .systemFont(ofSize: 16, weight: .semibold)
-        label.textColor = UIColor.rgba(84, 84, 84, 1)
-        return label
-    }()
+    var dailyAttendanceScore = PaddingLabel(radius: 5, color: UIColor(hex: 0x7FCBE5, alpha: 0.2))
     
     // MARK: - Initializer
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -67,40 +61,33 @@ class AttendanceHistoryCell: UITableViewCell {
         super.init(coder: coder)
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        self.accessoryType = .none
+    }
+    
     // MARK: - Helpers
     
     private func setupHistoryIndexView() -> UIView {
         let historyDateContainerView = UIView()
-        historyDateContainerView.addSubviews(weekLabel, dateLabel)
+        historyDateContainerView.addSubviews(weekLabel)
         weekLabel.snp.makeConstraints { make in
             make.verticalEdges.equalTo(historyDateContainerView)
             make.left.equalTo(historyDateContainerView)
-        }
-        dateLabel.snp.makeConstraints { make in
-            make.verticalEdges.equalTo(historyDateContainerView)
-            make.left.equalTo(weekLabel.snp.right).offset(5)
         }
         return historyDateContainerView
     }
     
     private func setupAttendanceStatusContainerView() {
-        let statusIconView = UIImageView(frame: CGRect(x: 0, y: 0, width: 20, height: 20))
-        let statusIcon = UIImage(systemName: "checkmark.circle.fill")
-        // 결석시 x.circle.fill
-        statusIconView.image = statusIcon
-        statusIconView.tintColor = .rgba(29, 186, 83, 1)
-        statusIconView.contentMode = .scaleAspectFit
-        // 지각시 rgba(222, 185, 90, 1)
-        // 결석시 rgba(232, 32, 68, 1)
-        
-        attendanceStatusContainerView.addSubviews(statusIconView, attendanceStatusLabel, attendedDatetime)
-        statusIconView.snp.makeConstraints { make in
+        attendanceStatusContainerView.addSubviews(statusIcon, attendanceStatusLabel, attendedDatetime)
+        statusIcon.snp.makeConstraints { make in
             make.top.equalTo(attendanceStatusContainerView.snp.top)
-            make.left.equalTo(attendanceStatusContainerView.snp.left)
+            make.leading.equalTo(attendanceStatusContainerView.snp.leading)
         }
         attendanceStatusLabel.snp.makeConstraints { make in
-            make.top.equalTo(statusIconView)
-            make.left.equalTo(statusIconView.snp.right).offset(5)
+            make.top.equalTo(attendanceStatusContainerView.snp.top)
+            make.leading.equalTo(statusIcon.snp.trailing).offset(6)
         }
         attendedDatetime.snp.makeConstraints { make in
             make.top.equalTo(attendanceStatusLabel.snp.bottom).offset(5)
@@ -109,31 +96,35 @@ class AttendanceHistoryCell: UITableViewCell {
     }
     
     private func setupCell() {
+        contentView.transform = CGAffineTransformMakeRotation(-.pi)
         contentView.snp.makeConstraints { make in
-            make.horizontalEdges.equalToSuperview().inset(10)
-            make.height.greaterThanOrEqualTo(60)
+            make.horizontalEdges.equalToSuperview().inset(24)
+            make.height.greaterThanOrEqualTo(84)
         }
+        
         let historyDateContainerView = setupHistoryIndexView()
         setupAttendanceStatusContainerView()
+        
+        dailyAttendanceScore.text = "0"
+        dailyAttendanceScore.textColor = .attendanceCheck
         
         contentView.addSubviews(historyDateContainerView, attendanceStatusContainerView, dailyAttendanceScore)
         historyDateContainerView.snp.makeConstraints { make in
             make.centerY.equalTo(contentView)
-            make.left.equalTo(contentView).offset(15)
-            make.width.equalTo(80)
+            make.leading.equalTo(contentView)
+            make.width.equalTo(74)
         }
         
         attendanceStatusContainerView.snp.makeConstraints { make in
             make.top.equalTo(historyDateContainerView)
-            make.left.equalTo(historyDateContainerView.snp.right).offset(20)
+            make.leading.equalTo(historyDateContainerView.snp.trailing).offset(16)
             make.width.equalTo(140)
             make.height.equalTo(50)
         }
         
         dailyAttendanceScore.snp.makeConstraints { make in
             make.top.equalTo(historyDateContainerView)
-            make.right.equalTo(contentView.snp.right).offset(-15)
-            make.width.equalTo(30)
+            make.trailing.equalTo(contentView.snp.trailing)
         }
     }
     

--- a/momoIOS/UserSide/PersonalInformation/AttendanceHistoryCell.swift
+++ b/momoIOS/UserSide/PersonalInformation/AttendanceHistoryCell.swift
@@ -8,13 +8,12 @@
 import UIKit
 import SnapKit
 
-
 class AttendanceHistoryCell: UITableViewCell {
 
     // MARK: - Properties
     
     static let id = "AttendanceHistoryCell"
-    
+
     private let attendanceStatusContainerView = UIView()
     
     var weekLabel: UILabel = {
@@ -96,7 +95,6 @@ class AttendanceHistoryCell: UITableViewCell {
     }
     
     private func setupCell() {
-        contentView.transform = CGAffineTransformMakeRotation(-.pi)
         contentView.snp.makeConstraints { make in
             make.horizontalEdges.equalToSuperview().inset(24)
             make.height.greaterThanOrEqualTo(84)
@@ -104,9 +102,6 @@ class AttendanceHistoryCell: UITableViewCell {
         
         let historyDateContainerView = setupHistoryIndexView()
         setupAttendanceStatusContainerView()
-        
-        dailyAttendanceScore.text = "0"
-        dailyAttendanceScore.textColor = .attendanceCheck
         
         contentView.addSubviews(historyDateContainerView, attendanceStatusContainerView, dailyAttendanceScore)
         historyDateContainerView.snp.makeConstraints { make in

--- a/momoIOS/UserSide/PersonalInformation/AttendanceResultCell.swift
+++ b/momoIOS/UserSide/PersonalInformation/AttendanceResultCell.swift
@@ -36,7 +36,7 @@ class AttendanceResultCell: UICollectionViewCell {
     
     override init(frame: CGRect) {
         super.init(frame: .zero)
-        contentView.backgroundColor = .white
+        contentView.backgroundColor = .clear
         setupCell()
     }
     

--- a/momoIOS/UserSide/PersonalInformation/AttendanceResultCell.swift
+++ b/momoIOS/UserSide/PersonalInformation/AttendanceResultCell.swift
@@ -40,6 +40,10 @@ class AttendanceResultCell: UICollectionViewCell {
         setupCell()
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+    }
+    
     // MARK: - Helpers
     private func setupCell() {
         layer.borderWidth = 1

--- a/momoIOS/UserSide/PersonalInformation/AttendanceResultCell.swift
+++ b/momoIOS/UserSide/PersonalInformation/AttendanceResultCell.swift
@@ -15,23 +15,16 @@ class AttendanceResultCell: UICollectionViewCell {
     
     var cellTitle: UILabel = {
         let title = UILabel()
-        title.font = .systemFont(ofSize: 15, weight: .medium)
-        title.textColor = .rgba(138, 138, 138, 1)
+        title.font = .body14
+        title.textColor = .gray600
         return title
     }()
     
     var attendanceResult: UILabel = {
         let result = UILabel()
-        result.font = .systemFont(ofSize: 40, weight: .regular)
-        result.textColor = .rgba(53, 53, 53, 1)
+        result.font = .pretendard(size: 39, weight: .w400)
+        result.textColor = .gray800
         return result
-    }()
-    
-    var resultScore: UILabel = {
-        let score = UILabel()
-        score.font = .systemFont(ofSize: 13, weight: .medium)
-        score.textColor = .rgba(217, 91, 91, 1)
-        return score
     }()
     
     // MARK: - Initializers
@@ -49,25 +42,19 @@ class AttendanceResultCell: UICollectionViewCell {
     
     // MARK: - Helpers
     private func setupCell() {
-        layer.shadowColor = UIColor.rgba(191, 191, 191, 1).cgColor
-        layer.shadowOpacity = 0.25
-        layer.shadowOffset = CGSize.zero
-        layer.shadowRadius = 10
-        contentView.addSubviews(cellTitle, attendanceResult, resultScore)
+        layer.borderWidth = 1
+        layer.borderColor = UIColor(hex: 0xEBEBEB).cgColor
+        layer.cornerRadius = 8
+        contentView.addSubviews(cellTitle, attendanceResult)
         
         cellTitle.snp.makeConstraints { make in
             make.centerX.equalTo(contentView)
-            make.top.equalTo(contentView).offset(10)
+            make.top.equalTo(contentView).offset(16)
         }
         
         attendanceResult.snp.makeConstraints { make in
             make.centerX.equalTo(contentView)
-            make.top.equalTo(cellTitle.snp.bottom).offset(9)
-        }
-        
-        resultScore.snp.makeConstraints { make in
-            make.centerX.equalTo(contentView)
-            make.top.equalTo(attendanceResult.snp.bottom)
+            make.top.equalTo(cellTitle.snp.bottom).offset(10)
         }
     }
 }

--- a/momoIOS/UserSide/PersonalInformation/PersonalInformationController.swift
+++ b/momoIOS/UserSide/PersonalInformation/PersonalInformationController.swift
@@ -147,8 +147,8 @@ class PersonalInformationController: UIViewController {
         
         scrollView.snp.makeConstraints { make in
             make.horizontalEdges.equalTo(view)
-            make.verticalEdges.equalTo(view.safeAreaLayoutGuide)
-            make.height.equalTo(2000)
+            make.top.equalTo(view.safeAreaLayoutGuide)
+            make.bottom.equalToSuperview()
         }
         
         contentView.snp.makeConstraints { make in
@@ -183,7 +183,7 @@ class PersonalInformationController: UIViewController {
         historyTableView.snp.makeConstraints { make in
             make.horizontalEdges.equalToSuperview()
             make.top.equalTo(borderView.snp.bottom)
-            make.bottom.equalToSuperview()
+            make.bottom.equalToSuperview().inset(30)
             make.height.equalTo(heightOfHistoryCell * numberOfHistory)
         }
     }

--- a/momoIOS/UserSide/PersonalInformation/PersonalInformationController.swift
+++ b/momoIOS/UserSide/PersonalInformation/PersonalInformationController.swift
@@ -16,11 +16,18 @@ class PersonalInformationController: UIViewController {
     private let data = [0: ("출석", 3),
                         1: ("지각", 0),
                         2: ("결석", 0)]
-    // indexPath.row: (title.text, result.text, score?.text)
+    // indexPath.row: (title.text, result.text)
     
-    private lazy var baseLayer: UIView = {
-        let layer = UIView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: 197))
-        layer.backgroundColor = UIColor(hex: 0x222328)
+    private let attendanceType: [AttendanceType: Attendance]
+    = [AttendanceType.present: Attendance(icon: "🔵", toString: "정상출석", textColor: UIColor.attendanceCheck, backgroundColor: UIColor(hex: 0x7FCBE5, alpha: 0.2), score: 0),
+       AttendanceType.late: Attendance(icon: "🟡", toString: "지각", textColor: UIColor(hex: 0xFF8E26), backgroundColor: UIColor(hex: 0xFFF8E4), score: -5),
+       AttendanceType.AWOL: Attendance(icon: "🔴", toString: "결석 (무단)", textColor: UIColor(hex: 0xFE505B), backgroundColor: UIColor(hex: 0xFFEFEF), score: -15),
+       AttendanceType.AWL: Attendance(icon: "🔴", toString: "결석 (통보)", textColor: UIColor(hex: 0xFE505B), backgroundColor: UIColor(hex: 0xFFEFEF), score: -10)]
+    
+    private lazy var baseLayer: UIImageView = {
+        let layer = UIImageView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: 197))
+        layer.image = UIImage(named: "profileBackgroundImage")
+        layer.contentMode = .scaleAspectFill
         return layer
     }()
     private let profileView = ProfileView()
@@ -91,29 +98,31 @@ class PersonalInformationController: UIViewController {
         resultCollectionView.translatesAutoresizingMaskIntoConstraints = false
         resultCollectionView.backgroundColor = .white
         resultCollectionView.register(AttendanceResultCell.self, forCellWithReuseIdentifier: AttendanceResultCell.id)
-        
         resultCollectionContainerView.addSubview(resultCollectionView)
         resultCollectionView.layer.masksToBounds = false
+        resultCollectionView.isScrollEnabled = false
+        
         resultCollectionView.snp.makeConstraints { make in
             make.verticalEdges.equalTo(resultCollectionContainerView)
             make.horizontalEdges.equalTo(resultCollectionContainerView)
         }
-        
-        view.addSubviews(resultCollectionContainerView)
     }
     
     private func setupHistoryTableView() {
         self.historyTableView.delegate = self
         self.historyTableView.dataSource = self
         self.historyTableView.register(AttendanceHistoryCell.self, forCellReuseIdentifier: AttendanceHistoryCell.id)
-        view.addSubviews(tableViewHeader, borderView, historyTableView)
         historyTableView.showsVerticalScrollIndicator = false
         historyTableView.allowsSelection = false
         historyTableView.separatorStyle = .none
+        historyTableView.transform = CGAffineTransformMakeRotation(-.pi)
+        historyTableView.isScrollEnabled = false
+        historyTableView.rowHeight = UITableView.automaticDimension
     }
     
     private func setupViews() {
-        view.addSubviews(baseLayer, profileView)
+        view.addSubviews(baseLayer, profileView, resultCollectionContainerView)
+        view.addSubviews(tableViewHeader, borderView, historyTableView)
         setupResultCollectionView()
         setupHistoryTableView()
     }
@@ -146,28 +155,33 @@ class PersonalInformationController: UIViewController {
         historyTableView.snp.makeConstraints { make in
             make.horizontalEdges.equalToSuperview()
             make.top.equalTo(borderView.snp.bottom)
-            make.bottom.equalToSuperview()
+            make.bottom.equalToSuperview().offset(350)
         }
     }
 }
 
 extension PersonalInformationController: UITableViewDelegate, UITableViewDataSource {
+
     func numberOfSections(in tableView: UITableView) -> Int {
            return 1
        }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 10
+        return 8
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if let cell = tableView.dequeueReusableCell(withIdentifier: AttendanceHistoryCell.id) {
-            return cell
-        } else {
-            let cell = UITableViewCell()
-            cell.backgroundColor = .black
-            return cell
-        }
+        let cell = tableView.dequeueReusableCell(withIdentifier: AttendanceHistoryCell.id, for: indexPath) as! AttendanceHistoryCell
+        let data = attendanceType.randomElement()!.value
+        cell.weekLabel.text = "\(indexPath.row+1)주차 (1/7)"
+        cell.statusIcon.text = "\(data.icon)"
+        cell.attendanceStatusLabel.text = data.toString
+        cell.dailyAttendanceScore.text = "\(data.score)"
+        cell.dailyAttendanceScore.verticalInset = 4
+        cell.dailyAttendanceScore.horizontalInset = 10
+        cell.dailyAttendanceScore.backgroundColor = data.backgroundColor
+        cell.dailyAttendanceScore.textColor = data.textColor
+        return cell
     }
 }
 

--- a/momoIOS/UserSide/PersonalInformation/PersonalInformationController.swift
+++ b/momoIOS/UserSide/PersonalInformation/PersonalInformationController.swift
@@ -13,35 +13,36 @@ class PersonalInformationController: UIViewController {
     // MARK: - Properties
     
     // 임시 데이터
-    private let data = [0: ("출석", 3, nil),
-                        1: ("지각", 0, nil),
-                        2: ("결석", 0, -30)]
+    private let data = [0: ("출석", 3),
+                        1: ("지각", 0),
+                        2: ("결석", 0)]
     // indexPath.row: (title.text, result.text, score?.text)
     
+    private lazy var baseLayer: UIView = {
+        let layer = UIView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: 197))
+        layer.backgroundColor = UIColor(hex: 0x222328)
+        return layer
+    }()
     private let profileView = ProfileView()
     private let historyTableView = UITableView()
     private let resultCollectionContainerView = UIView()
     private let resultCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout.init())
     
-    private lazy var hintLatePenalty = setupHintPenalty("-5점")
-    private lazy var hintAbsentPenalty = setupHintPenalty("통보 -10 / 무단 -15")
-    
-    private lazy var tableViewHeader: UIView = {
-        let header = UIView(frame: CGRect(x: 0, y: 0, width: view.frame.size.width, height: 38))
-        header.backgroundColor = UIColor.rgba(250, 250, 250, 1)
-        
-        let label = UILabel(frame: header.frame)
-        label.text = "출석 히스토리"
-        label.font = .systemFont(ofSize: 14, weight: .semibold)
-        label.textColor = UIColor.rgba(84, 84, 84, 1)
-        label.textAlignment = .left
-        
-        header.addSubview(label)
-        label.snp.makeConstraints { make in
-            make.left.equalTo(header.snp.left).offset(20)
-            make.centerY.equalTo(header.snp.centerY)
-        }
+    private lazy var tableViewHeader: UILabel = {
+        let header = UILabel()
+        header.text = "출석 히스토리"
+        header.font = .pretendard(size: 16, weight: .w600)
+        header.textColor = UIColor.gray700
         return header
+    }()
+    
+    private let borderView: UIView = {
+        let border = UIView()
+        border.backgroundColor = UIColor(hex: 0xF1F1F1)
+        border.snp.makeConstraints { make in
+            make.height.equalTo(0.75)
+        }
+        return border
     }()
     
     // MARK: - Lifecycles
@@ -64,38 +65,24 @@ class PersonalInformationController: UIViewController {
     // MARK: - Helpers
     
     private func setupCustomNav() {
-        // custom nav
-        let navBar = self.navigationController?.navigationBar
-        let appearance = UINavigationBarAppearance()
-        appearance.shadowColor = .rgba(24, 24, 24, 0.16)
-        appearance.backgroundColor = .white
-        navBar?.scrollEdgeAppearance = appearance
-        
         // back button (left)
         self.navigationItem.hidesBackButton = true
         navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "arrow.left"), style: .plain, target: self, action: #selector(goBackToMainVC))
+        navigationItem.leftBarButtonItem?.tintColor = .white
         
         // title (center)
         let title = UILabel()
         title.text = "나의 정보"
-        title.textColor = .black
-        title.font = .systemFont(ofSize: 15)
+        title.textColor = .textbox2
+        title.font = .body16
         navigationItem.titleView = title
         
         // logout (right)
         let logout = UILabel()
         logout.text = "로그아웃"
-        logout.textColor = .gray
-        logout.font = .systemFont(ofSize: 15)
+        logout.textColor = .textbox2
+        logout.font = .body14
         navigationItem.rightBarButtonItem = UIBarButtonItem(customView: logout)
-    }
-    
-    private func setupHintPenalty(_ hint: String) -> UILabel {
-        let hintLabel = UILabel()
-        hintLabel.text = hint
-        hintLabel.font = .systemFont(ofSize: 13)
-        hintLabel.textColor = .rgba(152, 152, 152, 1)
-        return hintLabel
     }
     
     private func setupResultCollectionView() {
@@ -108,25 +95,25 @@ class PersonalInformationController: UIViewController {
         resultCollectionContainerView.addSubview(resultCollectionView)
         resultCollectionView.layer.masksToBounds = false
         resultCollectionView.snp.makeConstraints { make in
-            make.verticalEdges.equalTo(resultCollectionContainerView).inset(20)
-            make.horizontalEdges.equalTo(resultCollectionContainerView).inset(20)
+            make.verticalEdges.equalTo(resultCollectionContainerView)
+            make.horizontalEdges.equalTo(resultCollectionContainerView)
         }
         
-        view.addSubviews(resultCollectionContainerView, hintLatePenalty, hintAbsentPenalty)
+        view.addSubviews(resultCollectionContainerView)
     }
     
     private func setupHistoryTableView() {
         self.historyTableView.delegate = self
         self.historyTableView.dataSource = self
         self.historyTableView.register(AttendanceHistoryCell.self, forCellReuseIdentifier: AttendanceHistoryCell.id)
-        view.addSubviews(tableViewHeader, historyTableView)
+        view.addSubviews(tableViewHeader, borderView, historyTableView)
         historyTableView.showsVerticalScrollIndicator = false
         historyTableView.allowsSelection = false
         historyTableView.separatorStyle = .none
     }
     
     private func setupViews() {
-        view.addSubview(profileView)
+        view.addSubviews(baseLayer, profileView)
         setupResultCollectionView()
         setupHistoryTableView()
     }
@@ -141,28 +128,24 @@ class PersonalInformationController: UIViewController {
         }
         
         resultCollectionContainerView.snp.makeConstraints { make in
-            make.horizontalEdges.equalToSuperview()
-            make.top.equalTo(profileView.snp.bottom).offset(20)
-            make.height.equalTo(135)
-        }
-        
-        hintAbsentPenalty.snp.makeConstraints { make in
-            make.right.equalToSuperview().inset(25)
-            make.top.equalTo(resultCollectionContainerView.snp.bottom)
-        }
-        hintLatePenalty.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.top.equalTo(resultCollectionContainerView.snp.bottom)
+            make.horizontalEdges.equalToSuperview().inset(24)
+            make.top.equalTo(profileView.snp.bottom).offset(26)
+            make.height.equalTo(110)
         }
         
         tableViewHeader.snp.makeConstraints { make in
-            make.horizontalEdges.equalToSuperview()
-            make.top.equalTo(hintLatePenalty.snp.bottom).offset(26)
-            make.height.equalTo(38)
+            make.leading.equalToSuperview().inset(24)
+            make.top.equalTo(resultCollectionView.snp.bottom).offset(35)
         }
+        
+        borderView.snp.makeConstraints { make in
+            make.top.equalTo(tableViewHeader.snp.bottom).offset(16)
+            make.horizontalEdges.equalToSuperview()
+        }
+        
         historyTableView.snp.makeConstraints { make in
             make.horizontalEdges.equalToSuperview()
-            make.top.equalTo(tableViewHeader.snp.bottom)
+            make.top.equalTo(borderView.snp.bottom)
             make.bottom.equalToSuperview()
         }
     }
@@ -191,7 +174,7 @@ extension PersonalInformationController: UITableViewDelegate, UITableViewDataSou
 extension PersonalInformationController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: (view.frame.width - 60) / 3, height: 105)
+        return CGSize(width: (view.frame.width - 72) / 3, height: 108)
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
@@ -203,9 +186,6 @@ extension PersonalInformationController: UICollectionViewDelegate, UICollectionV
         let data = data[indexPath.row]!
         cell.cellTitle.text = data.0
         cell.attendanceResult.text = indexPath.row == 2 ? "\(String(describing: data.1))/2" : "\(String(describing: data.1))"
-        if let score = data.2 {
-            cell.resultScore.text = "\(score)"
-        }
         return cell
     }
 }

--- a/momoIOS/UserSide/PersonalInformation/PersonalInformationController.swift
+++ b/momoIOS/UserSide/PersonalInformation/PersonalInformationController.swift
@@ -91,6 +91,10 @@ class PersonalInformationController: UIViewController {
         self.navigationController?.navigationBar.isTranslucent = true
         self.navigationController?.view.backgroundColor = .clear
         
+        let navigationBarAppearance = UINavigationBarAppearance()
+        navigationBarAppearance.backgroundColor = UIColor(hex: 0x222328)
+        navigationController?.navigationBar.standardAppearance = navigationBarAppearance
+        
         // title (center)
         let title = UILabel()
         title.text = "나의 정보"
@@ -115,6 +119,7 @@ class PersonalInformationController: UIViewController {
         resultCollectionContainerView.addSubview(resultCollectionView)
         resultCollectionView.layer.masksToBounds = false
         resultCollectionView.isScrollEnabled = false
+        resultCollectionView.contentInsetAdjustmentBehavior = .never
         
         resultCollectionView.snp.makeConstraints { make in
             make.verticalEdges.equalTo(resultCollectionContainerView)
@@ -133,9 +138,9 @@ class PersonalInformationController: UIViewController {
     }
     
     private func setupViews() {
-        view.addSubviews(scrollView, baseLayer)
+        view.addSubviews(scrollView)
         scrollView.addSubview(contentView)
-        contentView.addSubviews(profileView, resultCollectionContainerView, tableViewHeader, borderView, historyTableView)
+        contentView.addSubviews(baseLayer, profileView, resultCollectionContainerView, tableViewHeader, borderView, historyTableView)
         view.sendSubviewToBack(baseLayer)
         
         setupResultCollectionView()
@@ -147,7 +152,7 @@ class PersonalInformationController: UIViewController {
         
         scrollView.snp.makeConstraints { make in
             make.horizontalEdges.equalTo(view)
-            make.top.equalTo(view.safeAreaLayoutGuide)
+            make.top.equalToSuperview()
             make.bottom.equalToSuperview()
         }
         
@@ -159,7 +164,7 @@ class PersonalInformationController: UIViewController {
         }
         
         profileView.snp.makeConstraints { make in
-            make.top.equalTo(contentView.snp.top).offset(10)
+            make.top.equalTo(contentView.snp.top).offset(126)
             make.centerX.equalTo(contentView)
             make.height.equalTo(200)
         }


### PR DESCRIPTION
close #86 

- 프로필 view는 #80 
- 출결현황 Collection view GUI
- 출석 히스토리 Table view GUI
- table view, collection view 각각 스크롤막고 화면 전체 스크롤되도록 했습니다
- 스크롤시 네비게이션바의 글씨와 아래 배경색이 겹쳐 구분되지 않는 문제: 스크롤시엔 배경색을 주는 것으로 임시 해결
```Swift
let navigationBarAppearance = UINavigationBarAppearance()
navigationBarAppearance.backgroundColor = UIColor(hex: 0x222328)
navigationController?.navigationBar.standardAppearance = navigationBarAppearance
```
- 다음엔 뷰 나눠서 셀로 커스텀하도록 해야겠습니다 ,,,ㅎㅎ 😪

![Simulator Screen Recording - iPhone 14 Pro - 2023-02-28 at 17 11 49](https://user-images.githubusercontent.com/57654681/221795120-7c45ac8e-fb00-467a-9334-0c3d16e105fd.gif)

